### PR TITLE
投稿システムの改善

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,3 @@
+RUBY_DEBUG=1
+NODE_ENV=development
+RAILS_ENV=development

--- a/app/controllers/image_posts_controller.rb
+++ b/app/controllers/image_posts_controller.rb
@@ -2,15 +2,27 @@ class ImagePostsController < ApplicationController
   before_action :require_login
 
   def new
-    @image_post = if session[:temp_image_post]
-      ImagePost.new(session[:temp_image_post].except('image'))
+    if params[:from_confirm]
+      session[:from_confirm] = true
+      session[:post_params] = {} unless session[:post_params].is_a?(Hash)
+    end
+
+    if params[:image_post].present? && params[:image_post][:id].present?
+      @image_post = ImagePost.find(params[:image_post][:id])
+      session[:image_post_id] = @image_post.id
     else
-      ImagePost.new
+      @image_post = if session[:temp_image_post]
+        ImagePost.new(session[:temp_image_post].except('image'))
+      else
+        ImagePost.new
+      end
     end
   end
 
   def create
     if params[:image_post].nil?
+      session.delete(:image_post_id)
+      session[:no_image] = true
       redirect_to new_type_posts_path
       return
     end
@@ -18,49 +30,20 @@ class ImagePostsController < ApplicationController
     @image_post = ImagePost.new(image_post_params)
   
     if @image_post.save
-      # ここでお題を作成
-      theme = current_user.themes.build(
-        description: @image_post.description,
-        image_post: @image_post
-      )
-  
-      if @image_post.image.attached?
-        theme.image.attach(@image_post.image.blob)
+      if session[:image_post_id].present?
+        old_image_post = ImagePost.find_by(id: session[:image_post_id])
+        old_image_post&.destroy
       end
-  
-      theme.save
-  
+      
       session[:image_post_id] = @image_post.id
       session.delete(:temp_image_post)
+      session.delete(:no_image)
       redirect_to new_type_posts_path
     else
       session[:temp_image_post] = image_post_params.to_h
       flash.now[:alert] = '画像の投稿に失敗しました'
       render :new, status: :unprocessable_entity
     end
-  end
-
-  def complete
-    @image_post = ImagePost.find(session[:image_post_id])
-
-    if current_user
-      theme = current_user.themes.build(
-        description: @image_post.description,
-        image_post: @image_post
-      )
-  
-      if @image_post.image.attached?
-        theme.image.attach(@image_post.image.blob)
-      end
-      
-      if theme.save
-        flash[:notice] = 'お題が作成されました'
-      else
-        flash[:alert] = 'お題の作成に失敗しました'
-      end
-    end
-    
-    session.delete(:image_post_id)
   end
 
   private

--- a/app/views/image_posts/new.html.erb
+++ b/app/views/image_posts/new.html.erb
@@ -30,11 +30,17 @@
 
             <div class="text-center">
               <%= f.submit "次へ進む", class: "button button-primary me-2" %>
-              <%= button_to "画像なしで投稿", image_posts_path, method: :post, class: "button button-secondary" %>
+              <%= button_to "画像なしで投稿", image_posts_path, method: :post, class: "button button-secondary d-inline-block" %>
             </div>
           <% end %>
 
-          <%= render 'shared/back_button', fallback_path: root_path %>
+          <div class="text-center mt-4">
+            <% if session[:from_confirm] %>
+              <%= link_to "確認画面に戻る", confirm_posts_path, class: "button d-block mx-auto" %>
+            <% else %>
+              <%= render 'shared/back_button', fallback_path: root_path %>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/posts/confirm.html.erb
+++ b/app/views/posts/confirm.html.erb
@@ -1,61 +1,104 @@
 <% content_for :with_direction_toggle, true %>
 
-<div class="row justify-content-center">
-  <div class="col-md-8">
-    <h1 class="text-center mb-4">投稿内容の確認</h1>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <h1 class="text-center mb-4">投稿内容の確認</h1>
 
-    <div class="card mb-4">
-      <div class="card-body">
-        <% if @post.image_post.present? && @post.image_post.image.present? %>
-          <div class="mb-4">
-            <div class="image-container">
-              <%= image_tag @post.image_post.image, class: "w-100 rounded-lg" %>
+      <div class="card mb-4">
+        <div class="card-body">
+          <% if @theme %>
+            <div class="mb-4">
+              <h2 class="h5 mb-3">お題</h2>
+              <% if @theme.image.attached? %>
+                <div class="image-container">
+                  <%= image_tag url_for(@theme.image), class: "w-100 rounded-lg" %>
+                </div>
+              <% end %>
+              <p class="mt-2 text-muted"><%= @theme.description %></p>
             </div>
-            <% if @post.image_post.description.present? %>
-              <p class="mt-2 text-muted"><%= @post.image_post.description %></p>
-            <% end %>
-          </div>
-        <% end %>
-
-        <% if @post.theme.present? %>
-          <div class="mb-4">
-            <% if @post.theme.image.attached? %>
-              <div class="image-container">
-                <%= image_tag @post.theme.image, class: "w-100 rounded-lg" %>
+          <% else %>
+            <div class="mb-4">
+              <h2 class="h5 mb-3">画像</h2>
+              <% if @image_post.present? && @image_post.image.present? %>
+                <div class="image-container">
+                  <%= image_tag url_for(@image_post.image), class: "w-100 rounded-lg" %>
+                </div>
+                <% if @image_post.description.present? %>
+                  <p class="mt-2 text-muted"><%= @image_post.description %></p>
+                <% end %>
+              <% else %>
+                <p class="text-muted">画像なしで投稿します</p>
+              <% end %>
+              <div class="text-end">
+                <%= link_to (@image_post.present? ? '画像を変更する' : '画像を追加する'),
+                    new_image_post_path(
+                      from_confirm: true,
+                      post: session[:post_params]
+                    ),
+                    class: 'button' %>
               </div>
-            <% end %>
-            <p class="mt-2 text-muted"><%= @post.theme.description %></p>
+            </div>
+          <% end %>
+
+          <div class="mb-4">
+            <h2 class="h5 mb-3">選択した種類</h2>
+            <div class="d-flex justify-content-between align-items-center">
+              <span class="badge bg-primary"><%= @tag&.name %></span>
+              <%= link_to '種類選択に戻る',
+                  new_type_posts_path(
+                    from_confirm: true,
+                    post: session[:post_params],
+                    theme_id: @theme&.id
+                  ),
+                  class: 'button' %>
+            </div>
           </div>
-        <% end %>
 
-        <div class="d-flex justify-content-between align-items-start mb-3">
-          <span class="badge bg-primary"><%= @post.tags.first&.name %></span>
-        </div>
+          <div class="mb-4">
+            <h2 class="h5 mb-3">入力した読み方</h2>
+            <div class="d-flex justify-content-between align-items-center">
+              <div><%= @post.reading %></div>
+              <%= link_to '読み方入力に戻る',
+                  new_reading_posts_path(
+                    from_confirm: true,
+                    post: session[:post_params],
+                    theme_id: @theme&.id
+                  ),
+                  class: 'button' %>
+            </div>
+          </div>
 
-        <%= render partial: 'posts/post_content', locals: { content: @post.display_content } %>
+          <div class="mb-4">
+            <h2 class="h5 mb-3">入力した本文</h2>
+            <%= render partial: 'posts/post_content', locals: { content: @post.display_content } %>
+            <div class="text-end mt-2">
+              <%= link_to '本文入力に戻る',
+                  new_content_posts_path(
+                    from_confirm: true,
+                    post: session[:post_params],
+                    theme_id: @theme&.id
+                  ),
+                  class: 'button' %>
+            </div>
+          </div>
 
-        <div class="d-flex justify-content-between mt-4">
-          <%= button_to '戻る', { action: 'new_content' }, 
-              method: :get,
-              params: { 
-                content: @post.content,
-                theme_id: @post.theme_id,
-                tag: @post.tags.first&.name,
-                image_post: @post.image_post&.attributes&.slice('description')
-              },
-              class: 'button' %>
+          <div class="text-center mt-4">
+            <%= button_to '投稿する',
+                { action: 'create' },
+                method: :post,
+                params: {
+                  post: session[:post_params]
+                },
+                class: 'button button-primary',
+                form: { data: { turbo: false } } %>
 
-          <%= button_to '投稿する',
-              { action: 'create' },
-              method: :post,
-              params: { 
-                content: @post.content,
-                theme_id: @post.theme_id,
-                tag: @post.tags.first&.name,
-                image_post: @post.image_post&.attributes&.slice('description')
-              },
-              class: 'button button-primary',
-              form: { data: { turbo: false } } %>
+            <%= button_to '投稿を破棄する',
+                discard_posts_path,
+                method: :delete,
+                class: 'button button-danger mt-2',
+                data: { turbo_confirm: '投稿内容がすべて削除されます。本当によろしいですか？' } %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/posts/new_content.html.erb
+++ b/app/views/posts/new_content.html.erb
@@ -55,9 +55,19 @@
           <%= f.hidden_field :reading, value: @post&.reading %>
           <%= f.hidden_field :tag_id, value: @tag&.id %>
 
-          <div class="text-center mt-3">
+          <div class="text-center">
             <%= f.submit "確認", class: "button button-primary" %>
-            <%= link_to "戻る", new_reading_posts_path, class: "button" %>
+            <div class="mt-2">
+              <% if session[:from_confirm] %>
+                <%= link_to '確認画面に戻る',
+                    confirm_posts_path(
+                      post: session[:post_params]
+                    ),
+                    class: 'button' %>
+              <% else %>
+                <%= link_to "戻る", new_reading_posts_path, class: "button" %>
+              <% end %>
+            </div>
           </div>
         </div>
       <% end %>

--- a/app/views/posts/new_reading.html.erb
+++ b/app/views/posts/new_reading.html.erb
@@ -49,9 +49,19 @@
 
           <%= f.hidden_field :tag_id, value: session.dig(:post_params, 'tag_id') %>
 
-          <div class="text-center mt-3">
+          <div class="text-center">
             <%= f.submit "次へ", class: "button button-primary" %>
-            <%= link_to "戻る", new_type_posts_path, class: "button" %>
+            <div class="mt-2">
+              <% if session[:from_confirm] %>
+                <%= link_to '確認画面に戻る',
+                    confirm_posts_path(
+                      post: session[:post_params]
+                    ),
+                    class: 'button' %>
+              <% else %>
+                <%= link_to "戻る", new_type_posts_path, class: "button" %>
+              <% end %>
+            </div>
           </div>
         </div>
       <% end %>

--- a/app/views/posts/new_type.html.erb
+++ b/app/views/posts/new_type.html.erb
@@ -35,13 +35,23 @@
           </div>
         </div>
 
-        <div class="text-center mt-3">
+        <div class="text-center">
           <%= f.submit "次へ", class: "button button-primary" %>
-          <% if @theme %>
-            <%= link_to "戻る", theme_path(@theme), class: "button" %>
-          <% else %>
-            <%= link_to "戻る", new_image_post_path, class: "button" %>
-          <% end %>
+          <div class="mt-2">
+            <% if session[:from_confirm] %>
+              <%= link_to '確認画面に戻る', 
+                  confirm_posts_path(
+                    post: session[:post_params]
+                  ),
+                  class: 'button' %>
+            <% else %>
+              <% if @theme %>
+                <%= link_to "戻る", theme_path(@theme), class: "button" %>
+              <% else %>
+                <%= link_to "戻る", new_image_post_path, class: "button" %>
+              <% end %>
+            <% end %>
+          </div>
         </div>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       get :new_reading
       get :new_content
       get :confirm
+      delete :discard
     end
   end
 


### PR DESCRIPTION
# 投稿システムの改善

## 概要
投稿プロセスにおいて、ユーザーが最終的な投稿内容を確認できるように確認画面を実装しました。
これにより、投稿前に内容を見直す機能が追加され、投稿ミスの防止とユーザー体験の向上を実現しました。

## 実装内容
### 確認画面の追加
- 入力内容（画像、種類、読み方、本文）の確認表示
- お題からの投稿と通常投稿の両方に対応
- 投稿・破棄・各入力画面への戻る機能の実装

### 画面遷移の改善
- 確認画面からの戻る機能の実装（各入力ステップに戻れる）
- 入力内容の維持機能の実装
- セッションを活用した状態管理の実装

### デザインの統一
- 既存画面との統一感のあるデザイン
- レスポンシブ対応
- 直感的な操作性の確保

## 動作確認項目
1. [x] 確認画面の表示
   - 全入力内容の正しい表示
   - お題/画像の適切な表示
   - 入力内容の改行等の正確な反映
2. [x] 画面遷移
   - 各入力画面への戻り機能
   - 入力内容の維持
   - 投稿完了時の適切な遷移
3. [x] 入力内容の操作
   - 画像の変更/追加機能
   - 投稿内容の破棄機能
   - セッションデータの適切な管理

## 技術的変更点
- 確認画面用のアクション（confirm）の追加
- セッション管理による状態保持の実装
- 画像処理の改善（変更・追加機能）
- エラーハンドリングの強化

## テスト実施内容
- 新規投稿フローの動作確認
- お題からの投稿フローの動作確認
- 画像あり/なしの投稿確認
- 各画面からの戻る機能の確認
- エラー時の挙動確認

## 影響範囲
- 投稿フロー全体
- 画像投稿機能
- セッション管理
- 投稿完了処理

## 今後の検討事項
- プレビュー機能の拡充
- バリデーションの強化
- エラーメッセージの改善
- UXの更なる向上