### PR TITLE
ヘッダー・フッターのレイアウト改善

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,15 @@
+class PagesController < ApplicationController
+  skip_before_action :require_login
+
+  def about
+  end
+
+  def terms
+  end
+
+  def privacy
+  end
+
+  def contact
+  end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,7 +6,7 @@ class UserSessionsController < ApplicationController
   def create
     # emailでユーザーを検索
     user = User.find_by(email: params[:email])
-    
+
     # ユーザーが見つかり、かつ退会済みの場合
     if user&.deleted?
       flash.now[:alert] = 'このアカウントは削除されています'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :require_login, only: [:new, :create]
-  
+
   def new
     @user = User.new
   end
@@ -8,8 +8,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      auto_login(@user)
-      redirect_to root_path, notice: '新規登録が完了しました'
+      redirect_to root_path, notice: 'ユーザー登録が完了しました'
     else
       render :new, status: :unprocessable_entity
     end
@@ -17,7 +16,13 @@ class UsersController < ApplicationController
 
   def posts
     @user = User.find(params[:id])
-    @posts = @user.posts.order(created_at: :desc).page(params[:page]).per(10)
+    @posts = @user.posts.order(created_at: :desc).page(params[:page])
+  end
+
+  def themes
+    @user = User.find(params[:id])
+    @themes = @user.themes.order(created_at: :desc).page(params[:page])
+    render template: 'themes/index'
   end
 
   private

--- a/app/javascript/controllers/text_direction_controller.js
+++ b/app/javascript/controllers/text_direction_controller.js
@@ -2,58 +2,32 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["content", "toggle"]
-  static values = {
-    direction: String
-  }
 
   connect() {
     this.loadDirection()
-    // ページ読み込み時に現在の方向を設定
-    this.updateAllPages()
   }
 
   loadDirection() {
-    this.direction = localStorage.getItem('textDirection') || 'vertical'
-    this.updateDirection()
+    const direction = localStorage.getItem('textDirection') || 'horizontal'
+    this.updateDirection(direction)
   }
 
   toggle() {
-    this.direction = this.direction === 'vertical' ? 'horizontal' : 'vertical'
-    localStorage.setItem('textDirection', this.direction)
-    // 切り替え時に全ページの要素を更新
-    this.updateAllPages()
+    const currentDirection = localStorage.getItem('textDirection') || 'horizontal'
+    const newDirection = currentDirection === 'horizontal' ? 'vertical' : 'horizontal'
+    localStorage.setItem('textDirection', newDirection)
+    this.updateDirection(newDirection)
   }
 
-  updateDirection() {
-    // このコントローラーの配下の要素を更新
-    this.contentTargets.forEach(element => {
-      element.classList.remove('vertical-text', 'horizontal-text')
-      element.classList.add(`${this.direction}-text`)
-    })
-
-    // ボタンのテキストを更新
-    if (this.hasToggleTarget) {
-      this.toggleTarget.textContent = 
-        this.direction === 'vertical' ? '横書きに切り替え' : '縦書きに切り替え'
-    }
-  }
-
-  updateAllPages() {
-    // documentのすべてのpost-content要素を取得して更新
+  updateDirection(direction) {
     document.querySelectorAll('.post-content').forEach(element => {
       element.classList.remove('vertical-text', 'horizontal-text')
-      element.classList.add(`${this.direction}-text`)
+      element.classList.add(`${direction}-text`)
     })
 
-    // すべての切り替えボタンのテキストを更新
-    document.querySelectorAll('[data-text-direction-target="toggle"]').forEach(button => {
-      button.textContent = this.direction === 'vertical' ? '横書きに切り替え' : '縦書きに切り替え'
-    })
-
-    // カスタムイベントを発行して他のコントローラーに通知
-    const event = new CustomEvent('textDirectionChange', { 
-      detail: { direction: this.direction }
-    })
-    window.dispatchEvent(event)
+    if (this.hasToggleTarget) {
+      this.toggleTarget.textContent = 
+        direction === 'horizontal' ? '縦書きに切り替え' : '横書きに切り替え'
+    }
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,46 +11,46 @@
     <%= yield :page_javascript %>
   </head>
 
-  <body>
-    <div class="page-wrapper" data-controller="text-direction">
-      <header class="header">
-        <div class="header-container">
-          <div class="header-left">
-            <%= link_to 'ホーム', root_path, class: 'button' %>
-            <% if logged_in? %>
-              <%= link_to '句一覧', posts_path, class: 'button' %>
-              <%= link_to 'お題一覧', themes_path, class: 'button' %>
-            <% end %>
-          </div>
-
-          <div class="header-right">
-            <% if logged_in? %>
-              <%= link_to profile_path, class: 'text-decoration-none text-dark' do %>
-                <span class="fw-medium"><%= current_user.name %></span>
-              <% end %>
-              <%= link_to '句を詠む', new_image_post_path, class: 'button button-success ms-3' %>
-            <% else %>
-              <%= link_to 'ログイン', login_path, class: 'button' %>
-              <%= link_to '新規登録', signup_path, class: 'button' %>
-            <% end %>
-          </div>
-        </div>
-      </header>
-
-      <% if flash.any? %>
-        <div class="alert-wrapper">
-          <% flash.each do |key, value| %>
-            <div class="alert alert-<%= key == 'notice' ? 'success' : 'danger' %> text-center">
-              <%= value %>
-            </div>
+  <body class="d-flex flex-column min-vh-100">
+    <header class="header">
+      <div class="header-container">
+        <div class="header-left">
+          <%= link_to 'ホーム', root_path, class: 'button' %>
+          <% if logged_in? %>
+            <%= link_to '句一覧', posts_path, class: 'button' %>
+            <%= link_to 'お題一覧', themes_path, class: 'button' %>
           <% end %>
         </div>
-      <% end %>
 
-      <main class="main-content-wrapper">
+        <div class="header-right">
+          <% if logged_in? %>
+            <%= link_to profile_path, class: 'text-decoration-none text-dark' do %>
+              <span class="fw-medium"><%= current_user.name %></span>
+            <% end %>
+            <%= link_to '句を詠む', new_image_post_path, class: 'button button-success ms-3' %>
+          <% else %>
+            <%= link_to 'ログイン', login_path, class: 'button' %>
+            <%= link_to '新規登録', signup_path, class: 'button' %>
+          <% end %>
+        </div>
+      </div>
+    </header>
+
+    <% if flash.any? %>
+      <div class="alert-wrapper">
+        <% flash.each do |key, value| %>
+          <div class="alert alert-<%= key == 'notice' ? 'success' : 'danger' %> text-center">
+            <%= value %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <main class="flex-grow-1">
+      <div class="container py-4">
         <% if content_for?(:with_direction_toggle) %>
-          <div class="container">
-            <div class="direction-toggle-container text-end">
+          <div data-controller="text-direction">
+            <div class="text-end mb-3">
               <button type="button"
                       data-text-direction-target="toggle"
                       data-action="click->text-direction#toggle"
@@ -58,16 +58,18 @@
                 縦書き/横書き切り替え
               </button>
             </div>
-            <div class="writing-mode-container">
+            <div data-text-direction-target="content">
               <%= yield %>
             </div>
           </div>
         <% else %>
-          <div class="container">
-            <%= yield %>
-          </div>
+          <%= yield %>
         <% end %>
-      </main>
-    </div>
+      </div>
+    </main>
+
+    <footer class="footer mt-auto">
+      <%= render 'shared/footer' %>
+    </footer>
   </body>
 </html>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,0 +1,4 @@
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <h1 class="text-3xl font-bold mb-6">このサイトについて</h1>
+  <!-- コンテンツを追加 -->
+</div>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -1,0 +1,4 @@
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <h1 class="text-3xl font-bold mb-6">お問い合わせ</h1>
+  <!-- コンテンツを追加 -->
+</div>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,0 +1,4 @@
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <h1 class="text-3xl font-bold mb-6">プライバシーポリシー</h1>
+  <!-- コンテンツを追加 -->
+</div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,0 +1,4 @@
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <h1 class="text-3xl font-bold mb-6">利用規約</h1>
+  <!-- コンテンツを追加 -->
+</div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,10 +1,16 @@
-<div class="card mb-3">
+<div class="card mb-4">
   <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
     <div class="card-body">
-      <div class="d-flex justify-content-between align-items-start mb-2">
-        <div class="tags">
-          <span class="badge bg-primary me-1"><%= post.tags.first&.name %></span>
+      <% if post.image_post&.image.present? %>
+        <div class="mb-4">
+          <%= image_tag url_for(post.image_post.image), class: "w-100 rounded" %>
+          <% if post.image_post.description.present? %>
+            <p class="mt-2 text-muted small"><%= post.image_post.description %></p>
+          <% end %>
         </div>
+      <% end %>
+      <div class="d-flex justify-content-between align-items-start mb-3">
+        <span class="badge bg-primary"><%= post.tags.first&.name %></span>
         <small class="text-muted"><%= l post.created_at, format: :long %></small>
       </div>
       <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>

--- a/app/views/posts/_post_content.html.erb
+++ b/app/views/posts/_post_content.html.erb
@@ -1,3 +1,3 @@
-<div class="post-content" data-text-direction-target="content">
+<div class="post-content horizontal-text">  <!-- デフォルトで横書き -->
   <%= simple_format(content) %>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -27,7 +27,7 @@
                   <% end %>
                 </div>
               <% end %>
-              
+
               <div class="d-flex justify-content-between align-items-start mb-2">
                 <div class="tags">
                   <span class="badge bg-primary me-1"><%= post.tags.first&.name %></span>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -18,8 +18,8 @@
         <div class="mt-4 d-flex gap-2 flex-wrap">
           <%= link_to '編集', edit_profile_path, class: 'button' %>
           <%= link_to 'パスワード変更', password_profile_path, class: 'button' %>
-          <%= button_to 'ログアウト', 
-              logout_path, 
+          <%= button_to 'ログアウト',
+              logout_path,
               method: :delete,
               class: 'button',
               data: { turbo: true } %>
@@ -30,32 +30,14 @@
     <div>
       <div class="d-flex justify-content-between align-items-center mb-3">
         <h3 class="h5 mb-0">投稿した句一覧</h3>
-        <%= link_to "すべての句を見る (#{@posts.count})", posts_user_path(@user), 
+        <%= link_to "すべての句を見る (#{@posts.count})", posts_user_path(@user.id),
             class: "text-decoration-none" %>
       </div>
 
       <% if @posts.exists? %>
         <div class="grid gap-4">
           <% @posts.limit(3).each do |post| %>
-            <div class="card mb-4">
-              <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
-                <div class="card-body">
-                  <% if post.image_post&.image.present? %>
-                    <div class="mb-4">
-                      <%= image_tag url_for(post.image_post.image), class: "w-100 rounded" %>
-                      <% if post.image_post.description.present? %>
-                        <p class="mt-2 text-muted small"><%= post.image_post.description %></p>
-                      <% end %>
-                    </div>
-                  <% end %>
-                  <div class="d-flex justify-content-between align-items-start mb-3">
-                    <span class="badge bg-primary"><%= post.tags.first&.name %></span>
-                    <small class="text-muted"><%= l post.created_at, format: :long %></small>
-                  </div>
-                  <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
-                </div>
-              <% end %>
-            </div>
+            <%= render partial: 'posts/post', locals: { post: post } %>
           <% end %>
         </div>
       <% else %>
@@ -66,7 +48,7 @@
     <div class="mb-4">
       <div class="d-flex justify-content-between align-items-center mb-3">
         <h3 class="h5 mb-0">作成したお題一覧</h3>
-        <%= link_to "すべてのお題を見る (#{@user.themes.count})", themes_user_path(@user), 
+        <%= link_to "すべてのお題を見る (#{@user.themes.count})", themes_user_path(@user.id),
             class: "text-decoration-none" %>
       </div>
 
@@ -79,7 +61,7 @@
 
     <div class="card mb-4">
       <div class="card-body text-center">
-        <%= button_to '退会する', 
+        <%= button_to '退会する',
             deactivate_registration_path,
             method: :delete,
             class: 'button button-danger',

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,23 @@
+<footer class="footer py-3 bg-light mt-auto">
+  <div class="container">
+    <nav class="d-flex justify-content-center mb-3">
+      <ul class="nav">
+        <li class="nav-item mx-3">
+          <%= link_to "このサイトについて", about_path, class: "btn btn-outline-secondary" %>
+        </li>
+        <li class="nav-item mx-3">
+          <%= link_to "利用規約", terms_path, class: "btn btn-outline-secondary" %>
+        </li>
+        <li class="nav-item mx-3">
+          <%= link_to "プライバシーポリシー", privacy_path, class: "btn btn-outline-secondary" %>
+        </li>
+        <li class="nav-item mx-3">
+          <%= link_to "お問い合わせ", contact_path, class: "btn btn-outline-secondary" %>
+        </li>
+      </ul>
+    </nav>
+    <div class="text-center text-muted">
+      <p class="mb-0">&copy; <%= Time.current.year %> ひとひ人七. All rights reserved.</p>
+    </div>
+  </div>
+</footer>

--- a/app/views/themes/_theme.html.erb
+++ b/app/views/themes/_theme.html.erb
@@ -2,19 +2,17 @@
   <%= link_to theme_path(theme), class: "text-decoration-none", data: { turbo: false } do %>
     <div class="card-body">
       <% if theme.image.attached? %>
-        <%= image_tag theme.image, class: "w-100 rounded-lg mb-3" %>
+        <div class="mb-3">
+          <%= image_tag theme.display_image, class: "w-100 rounded" %>
+        </div>
       <% end %>
-      
-      <div class="mb-3">
-        <p class="text-muted"><%= theme.description %></p>
+
+      <div class="d-flex justify-content-between align-items-start mb-2">
+        <span class="badge bg-primary">お題</span>
+        <small class="text-muted"><%= l theme.created_at, format: :long %></small>
       </div>
 
-      <div class="d-flex justify-content-between align-items-center">
-        <small class="text-muted">
-          <%= l theme.created_at, format: :long %>
-          <span class="ms-2">投稿数: <%= theme.posts.count %></span>
-        </small>
-      </div>
+      <p class="mb-0 text-dark"><%= theme.description %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/themes/_theme.html.erb
+++ b/app/views/themes/_theme.html.erb
@@ -6,13 +6,17 @@
           <%= image_tag theme.display_image, class: "w-100 rounded" %>
         </div>
       <% end %>
-
+      
       <div class="d-flex justify-content-between align-items-start mb-2">
         <span class="badge bg-primary">お題</span>
         <small class="text-muted"><%= l theme.created_at, format: :long %></small>
       </div>
 
       <p class="mb-0 text-dark"><%= theme.description %></p>
+
+      <div class="text-muted mt-3">
+        <small>投稿数: <%= theme.posts.count %>件</small>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/themes/all_posts.html.erb
+++ b/app/views/themes/all_posts.html.erb
@@ -1,44 +1,38 @@
 <% content_for :with_direction_toggle, true %>
 
-<div class="row justify-content-center">
-  <div class="col-md-8">
-    <div class="card mb-3">
-      <div class="card-body">
-        <% if @theme.image.attached? %>
-          <%= image_tag @theme.image, class: "w-100 rounded-lg" %>
-        <% end %>
-        
-        <div class="mt-2">
-          <p class="text-muted"><%= @theme.description %></p>
-        </div>
 
-        <div class="mt-4">
-          <h2 class="h4 mb-4">このお題で詠まれた句（<%= @posts.total_count %>件）</h2>
-          <div class="grid gap-4">
-            <% @posts.each do |post| %>
-              <div class="card mb-3">
-                <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
-                  <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-2">
-                      <div class="tags">
-                        <span class="badge bg-primary me-1"><%= post.tags.first&.name %></span>
-                      </div>
-                      <small class="text-muted"><%= l post.created_at, format: :long %></small>
-                    </div>
-                    <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
-                  </div>
-                <% end %>
-              </div>
-            <% end %>
 
-            <div class="mt-4">
-              <%= paginate @posts %>
-            </div>
-          </div>
-        </div>
-
-        <%= render 'shared/back_button', fallback_path: theme_path(@theme) %>
-      </div>
-    </div>
+<% if @theme.image.attached? %>
+  <div class="text-center mb-4">
+    <%= image_tag @theme.display_image, class: "rounded" %>
+    <p class="mt-2"><%= @theme.description %></p>
   </div>
+<% end %>
+
+<h2 class="text-center mb-4">このお題で詠まれた句 （<%= @posts.total_count %>件）</h2>
+
+<% if @posts.any? %>
+  <% @posts.each do |post| %>
+    <div class="card mb-4">
+      <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-start mb-2">
+            <span class="badge bg-primary"><%= post.tags.first&.name %></span>
+            <small class="text-muted"><%= l post.created_at, format: :long %></small>
+          </div>
+          <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div class="mt-4">
+    <%= paginate @posts %>
+  </div>
+<% else %>
+  <p class="text-center text-muted">まだ句が詠まれていません</p>
+<% end %>
+
+<div class="text-center mt-4">
+  <%= link_to '戻る', 'javascript:history.back()', class: 'text-decoration-none' %>
 </div>

--- a/app/views/themes/index.html.erb
+++ b/app/views/themes/index.html.erb
@@ -1,16 +1,19 @@
-<div class="row justify-content-center">
-  <div class="col-md-8">
-    <h1 class="text-center mb-4">お題一覧</h1>
-    <% if @themes.present? %>
-      <% @themes.each do |theme| %>
-        <%= render partial: 'themes/theme', locals: { theme: theme } %>
-      <% end %>
-    <% else %>
-      <p class="text-center text-muted">お題はまだありません</p>
-    <% end %>
+<% content_for :with_direction_toggle, false %>
 
-    <div class="mt-4">
-      <%= paginate @themes %>
+<h1 class="text-center mb-4">お題一覧</h1>
+
+<% if @themes.any? %>
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <% @themes.each do |theme| %>
+        <%= render partial: 'theme', locals: { theme: theme } %>
+      <% end %>
+
+      <div class="d-flex justify-content-center mt-4">
+        <%= paginate @themes %>
+      </div>
     </div>
   </div>
-</div>
+<% else %>
+  <p class="text-center text-muted">お題がありません</p>
+<% end %>

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -7,7 +7,7 @@
         <% if @theme.image.attached? %>
           <%= image_tag @theme.image, class: "w-100 rounded-lg" %>
         <% end %>
-        
+
         <div class="mt-2">
           <p class="text-muted"><%= @theme.description %></p>
         </div>
@@ -74,19 +74,19 @@
         <% end %>
 
         <div class="text-center mt-4">
-          <%= link_to "このお題で詠まれたすべての句（#{@total_posts_count}件）", 
-                    all_posts_theme_path(@theme), 
+          <%= link_to "このお題で詠まれたすべての句（#{@total_posts_count}件）",
+                    all_posts_theme_path(@theme),
                     class: "text-decoration-none" %>
         </div>
-        
+
         <% if logged_in? && !@theme.posted_by?(current_user) && current_user != @theme.user %>
-          <%= link_to 'このお題で詠む', new_type_theme_posts_path(@theme), 
+          <%= link_to 'このお題で詠む', new_type_theme_posts_path(@theme),
               class: "button button-primary mt-4 d-block text-center" %>
         <% end %>
 
         <% if logged_in? && current_user == @theme.user %>
           <div class="mt-4">
-            <%= button_to '削除', theme_path(@theme), 
+            <%= button_to '削除', theme_path(@theme),
                 method: :delete,
                 data: { turbo_confirm: "このお題を削除してもよろしいですか？\n（このお題で詠まれた句は削除されません）" },
                 class: 'button button-danger' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resources :users, only: [:create] do
     member do
       get 'posts'
-      get 'themes', to: 'themes#user_themes'
+      get 'themes'
     end
   end
 
@@ -54,4 +54,10 @@ Rails.application.routes.draw do
   resource :registration, only: [] do
     delete 'deactivate', to: 'registrations#deactivate'
   end
+
+  # フッター用のルーティング
+  get 'about', to: 'pages#about', as: :about
+  get 'terms', to: 'pages#terms', as: :terms
+  get 'privacy', to: 'pages#privacy', as: :privacy
+  get 'contact', to: 'pages#contact', as: :contact
 end


### PR DESCRIPTION
# ヘッダー・フッターのレイアウト改善

## 概要
アプリケーション全体のレイアウトを改善し、特にヘッダーとフッターの表示を最適化しました。
また、お題一覧の表示を句一覧と同様のデザインに統一しました。

## 実装内容
### レイアウト改善
- フッターを画面最下部に固定
- コンテンツ量に応じたフッター位置の適切な調整
- ヘッダーとの整合性を考慮したレイアウト調整

### デザイン統一
- お題一覧のカードサイズを句一覧と統一
- 画像表示サイズの標準化
- バッジやボタンのデザイン統一

### 機能改善
- 縦書き・横書き切り替えの安定化
- コンテンツ表示領域の最適化

## 動作確認項目
1. [x] フッター表示
   - スクロール時の動作確認
   - コンテンツ量による位置調整
   - レスポンシブ対応
2. [x] お題一覧表示
   - カードサイズの統一
   - 画像表示の確認
   - レイアウトの一貫性
3. [x] 縦書き・横書き切り替え
   - 切り替え機能の動作
   - レイアウトへの影響確認

## 技術的変更点
- Flexboxを使用したフッター配置の実装
- カードコンポーネントのスタイル統一
- 縦書き・横書き切り替えの改善

## テスト実施内容
- 各画面でのフッター表示確認
- コンテンツ量の異なる画面での表示確認
- レスポンシブ動作の確認
- お題一覧と句一覧の表示比較

## 影響範囲
- アプリケーション全体のレイアウト
- お題一覧表示
- フッター表示位置
- 縦書き・横書き切り替え機能

## 補足事項
- 今回の変更ではフッターのリンク先の実装は含まれていません
- プロフィール画面の調整は別途対応予定です