### PR TITLE
50 like function

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,51 @@
+class LikesController < ApplicationController
+  before_action :require_login
+  before_action :set_likeable, only: [:create]
+  before_action :set_like, only: [:destroy]
+
+  def create
+    @like = current_user.likes.build(likeable: @likeable)
+
+    if @like.save
+      flash[:notice] = "いいねしました"
+      redirect_back_or_to @likeable
+    else
+      flash[:alert] = @like.errors.full_messages.join(", ")
+      redirect_back_or_to @likeable
+    end
+  end
+
+  def destroy
+    if @like.destroy
+      flash[:notice] = "いいねを取り消しました"
+      redirect_back_or_to @like.likeable
+    else
+      flash[:alert] = "いいねの取り消しに失敗しました"
+      redirect_back_or_to @like.likeable
+    end
+  end
+
+  private
+
+  def set_likeable
+    type = params[:likeable_type]
+    id = params[:likeable_id]
+
+    if ['Post', 'Theme'].include?(type)
+      @likeable = type.constantize.find(id)
+    else
+      flash[:alert] = "無効なリクエストです"
+      redirect_back fallback_location: root_path
+    end
+  end
+
+  def set_like
+    @like = current_user.likes.find_by!(
+      likeable_type: params[:likeable_type],
+      likeable_id: params[:likeable_id]
+    )
+  rescue ActiveRecord::RecordNotFound
+    flash[:alert] = "いいねが見つかりませんでした"
+    redirect_back fallback_location: root_path
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,22 +1,23 @@
 class ProfilesController < ApplicationController
   before_action :require_login
-  
+
   def show
     begin
       @user = current_user
       @posts = @user.posts.includes(:tags, :image_post).order(created_at: :desc)
       @image_post = ImagePost.find_by(id: session[:image_post_id]) if session[:image_post_id]
+      @show_like_button = false
     rescue => e
       logger.error "Error in profiles#show: #{e.message}"
       flash.now[:alert] = "プロフィールの取得中にエラーが発生しました"
       @posts = Post.none
     end
   end
-  
+
   def edit
     @user = current_user
   end
-  
+
   def update
     @user = current_user
     if @user.update(user_params)
@@ -25,11 +26,11 @@ class ProfilesController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
-  
+
   def edit_password
     @user = current_user
   end
-  
+
   def update_password
     @user = current_user
     if @user.update(password_params)
@@ -38,13 +39,13 @@ class ProfilesController < ApplicationController
       render :edit_password, status: :unprocessable_entity
     end
   end
-  
+
   private
-  
+
   def user_params
     params.require(:user).permit(:email, :name)
   end
-  
+
   def password_params
     params.require(:user).permit(:password, :password_confirmation)
   end

--- a/app/models/image_post.rb
+++ b/app/models/image_post.rb
@@ -1,7 +1,31 @@
 class ImagePost < ApplicationRecord
   has_many :posts
-  has_many :themes, dependent: :destroy
+  has_one :theme
+  has_many :posts, dependent: :nullify
   has_one_attached :image
 
-  validates :description, presence: true
+  validates :description, length: { maximum: 10 }
+
+  validates :image,
+    content_type: {
+      in: ['image/png', 'image/jpg', 'image/jpeg'],
+      message: 'はPNG、JPEG、JPG形式のみが対応しています'
+    },
+    size: {
+      less_than: 5.megabytes,
+      message: 'は5MB以下にしてください'
+    },
+    allow_nil: true
+
+  def display_image
+    if image.attached?
+      image.variant(resize_to_limit: [400, 300])
+    end
+  end
+
+  def small_image
+    if image.attached?
+      image.variant(resize_to_limit: [200, 150])
+    end
+  end
 end

--- a/app/models/image_post.rb
+++ b/app/models/image_post.rb
@@ -1,30 +1,7 @@
 class ImagePost < ApplicationRecord
+  has_many :posts
+  has_many :themes, dependent: :destroy
   has_one_attached :image
-  has_one :theme
-  has_many :posts, dependent: :nullify
-  
-  validates :description, length: { maximum: 10 }
-  
-  validates :image,
-    content_type: { 
-      in: ['image/png', 'image/jpg', 'image/jpeg'], 
-      message: 'はPNG、JPEG、JPG形式のみ対応しています'
-    },
-    size: { 
-      less_than: 5.megabytes, 
-      message: 'は5MB以下にしてください'
-    },
-    allow_nil: true
 
-  def display_image
-    if image.attached?
-      image.variant(resize_to_limit: [400, 300])
-    end
-  end
-
-  def small_image
-    if image.attached?
-      image.variant(resize_to_limit: [200, 150])
-    end
-  end
+  validates :description, presence: true
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,15 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :likeable, polymorphic: true, counter_cache: true
+  
+  validates :user_id, uniqueness: { scope: [:likeable_type, :likeable_id] }
+  validate :cannot_like_own_content
+
+  private
+
+  def cannot_like_own_content
+    if user_id == likeable.user_id
+      errors.add(:base, "自分の投稿にはいいねできません")
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,6 +9,8 @@ class Post < ApplicationRecord
   belongs_to :image_post, optional: true
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
+  has_many :likes, as: :likeable, dependent: :destroy
+  has_many :users_who_liked, through: :likes, source: :user
 
   validates :reading, presence: { message: "読み方を入力してください" }
   validates :display_content, presence: { message: "本文が入力されていません" }

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -3,6 +3,8 @@ class Theme < ApplicationRecord
   belongs_to :image_post, optional: true, dependent: :destroy
   has_many :posts, dependent: :nullify
   has_one_attached :image
+  has_many :likes, as: :likeable, dependent: :destroy
+  has_many :users_who_liked, through: :likes, source: :user
 
   validates :description, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,12 +2,19 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :posts
   has_many :themes
+  has_many :likes, dependent: :destroy
+  has_many :liked_posts, through: :likes, source: :likeable, source_type: 'Post'
+  has_many :liked_themes, through: :likes, source: :likeable, source_type: 'Theme'
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :email, uniqueness: true, presence: true
   validates :name, presence: true
+
+  def likes?(likeable)
+    likes.exists?(likeable: likeable)
+  end
 
   def soft_delete
     update(deleted_at: Time.current)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <%= yield :page_javascript %>
   </head>
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,7 +1,12 @@
 <div class="card mb-4">
   <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
     <div class="card-body">
-      <% if post.image_post&.image.present? %>
+      <% if post.theme&.image&.attached? %>
+        <div class="mb-4">
+          <%= image_tag post.theme.display_image, class: "w-100 rounded" %>
+          <p class="mt-2 text-muted small"><%= post.theme.description %></p>
+        </div>
+      <% elsif post.image_post&.image.present? %>
         <div class="mb-4">
           <%= image_tag url_for(post.image_post.image), class: "w-100 rounded" %>
           <% if post.image_post.description.present? %>
@@ -16,4 +21,10 @@
       <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
     </div>
   <% end %>
+  
+  <div class="card-footer bg-transparent">
+    <div class="d-flex justify-content-end">
+      <%= render 'shared/like_count', likeable: post %>
+    </div>
+  </div>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,50 +1,19 @@
 <% content_for :with_direction_toggle, true %>
 
+<h1 class="text-center mb-4">句一覧</h1>
+
 <div class="row justify-content-center">
   <div class="col-md-8">
-    <h1 class="text-center mb-4">句一覧</h1>
-    <% if @posts.present? %>
+    <% if @posts.any? %>
       <% @posts.each do |post| %>
-        <div class="card mb-3">
-          <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
-            <div class="card-body">
-              <% if post.theme.present? %>
-                <div class="mb-4">
-                  <% if post.theme.image.attached? %>
-                    <div class="image-container-small">
-                      <%= image_tag post.theme.image, class: "w-100 rounded-lg theme-image-small" %>
-                    </div>
-                  <% end %>
-                  <p class="mt-2 text-muted"><%= post.theme.description %></p>
-                </div>
-              <% elsif post.image_post&.image.present? %>
-                <div class="mb-4">
-                  <div class="image-container-small">
-                    <%= image_tag post.image_post.image, class: "w-100 rounded-lg theme-image-small" %>
-                  </div>
-                  <% if post.image_post.description.present? %>
-                    <p class="mt-2 text-muted"><%= post.image_post.description %></p>
-                  <% end %>
-                </div>
-              <% end %>
-
-              <div class="d-flex justify-content-between align-items-start mb-2">
-                <div class="tags">
-                  <span class="badge bg-primary me-1"><%= post.tags.first&.name %></span>
-                </div>
-                <small class="text-muted"><%= l post.created_at, format: :long %></small>
-              </div>
-              <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
-            </div>
-          <% end %>
-        </div>
+        <%= render partial: 'post', locals: { post: post, show_like_button: false } %>
       <% end %>
 
-      <div class="mt-4">
-        <%= paginate @posts, window: 2 %>
+      <div class="d-flex justify-content-center mt-4">
+        <%= paginate @posts %>
       </div>
     <% else %>
-      <p class="text-center text-muted">投稿された句はありません。</p>
+      <p class="text-center text-muted">まだ句が投稿されていません</p>
     <% end %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -33,6 +33,16 @@
 
         <%= render partial: 'posts/post_content', locals: { content: @post.display_content } %>
 
+        <div class="d-flex justify-content-end mt-3">
+          <% if @show_like_button %>
+            <%= render 'shared/like_button', likeable: @post %>
+          <% else %>
+            <div class="likes-count text-muted">
+              <i class="far fa-heart"></i> <%= @post.likes_count %>
+            </div>
+          <% end %>
+        </div>
+
         <% if logged_in? && current_user == @post.user %>
           <div class="mt-3">
             <%= button_to '削除', post_path(@post), 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -37,7 +37,7 @@
       <% if @posts.exists? %>
         <div class="grid gap-4">
           <% @posts.limit(3).each do |post| %>
-            <%= render partial: 'posts/post', locals: { post: post } %>
+            <%= render partial: 'posts/post', locals: { post: post, show_like_button: false } %>
           <% end %>
         </div>
       <% else %>
@@ -53,7 +53,7 @@
       </div>
 
       <% if @user.themes.exists? %>
-        <%= render partial: 'themes/theme', collection: @user.themes.order(created_at: :desc).limit(3) %>
+        <%= render partial: 'themes/theme', collection: @user.themes.order(created_at: :desc).limit(3), locals: { show_like_button: false } %>
       <% else %>
         <p class="text-center text-muted">まだお題を作成していません</p>
       <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="footer py-3 bg-light mt-auto">
+<footer class="footer py-3 bg-light mt-auto border-top">
   <div class="container">
     <nav class="d-flex justify-content-center mb-3">
       <ul class="nav">

--- a/app/views/shared/_like_button.html.erb
+++ b/app/views/shared/_like_button.html.erb
@@ -1,0 +1,43 @@
+<div class="d-flex align-items-center gap-2">
+  <% if logged_in? && current_user != likeable.user %>
+    <% if current_user.likes?(likeable) %>
+      <%= button_to unlike_path(likeable_type: likeable.class.name, likeable_id: likeable.id),
+          method: :delete,
+          class: "btn p-0 border-0 bg-transparent like-button",
+          data: { turbo: false } do %>
+        <div class="d-flex align-items-center gap-2">
+          <span class="like-heart text-danger">♥</span>
+          <span class="text-muted"><%= likeable.likes_count %></span>
+        </div>
+      <% end %>
+    <% else %>
+      <%= button_to like_path(likeable_type: likeable.class.name, likeable_id: likeable.id),
+          method: :post,
+          class: "btn p-0 border-0 bg-transparent like-button",
+          data: { turbo: false } do %>
+        <div class="d-flex align-items-center gap-2">
+          <span class="like-heart">♡</span>
+          <span class="text-muted"><%= likeable.likes_count %></span>
+        </div>
+      <% end %>
+    <% end %>
+  <% else %>
+    <div class="d-flex align-items-center gap-2">
+      <span class="like-heart">♡</span>
+      <span class="text-muted"><%= likeable.likes_count %></span>
+    </div>
+  <% end %>
+</div>
+
+<style>
+  .like-heart {
+    font-size: 1.2rem;
+    line-height: 1;
+  }
+  .like-button {
+    text-decoration: none !important;
+  }
+  .like-button:hover {
+    opacity: 0.7;
+  }
+</style>

--- a/app/views/shared/_like_count.html.erb
+++ b/app/views/shared/_like_count.html.erb
@@ -1,0 +1,11 @@
+<div class="d-flex align-items-center gap-2">
+  <span class="like-heart <%= logged_in? && current_user.likes?(likeable) ? 'text-danger' : '' %>"><%= logged_in? && current_user.likes?(likeable) ? '♥' : '♡' %></span>
+  <span class="text-muted"><%= likeable.likes_count %></span>
+</div>
+
+<style>
+  .like-heart {
+    font-size: 1.2rem;
+    line-height: 1;
+  }
+</style>

--- a/app/views/themes/_theme.html.erb
+++ b/app/views/themes/_theme.html.erb
@@ -6,7 +6,7 @@
           <%= image_tag theme.display_image, class: "w-100 rounded" %>
         </div>
       <% end %>
-      
+
       <div class="d-flex justify-content-between align-items-start mb-2">
         <span class="badge bg-primary">お題</span>
         <small class="text-muted"><%= l theme.created_at, format: :long %></small>
@@ -19,4 +19,10 @@
       </div>
     </div>
   <% end %>
+
+  <div class="card-footer bg-transparent">
+    <div class="d-flex justify-content-end">
+      <%= render 'shared/like_count', likeable: theme %>
+    </div>
+  </div>
 </div>

--- a/app/views/themes/index.html.erb
+++ b/app/views/themes/index.html.erb
@@ -6,7 +6,7 @@
   <div class="row justify-content-center">
     <div class="col-md-8">
       <% @themes.each do |theme| %>
-        <%= render partial: 'theme', locals: { theme: theme } %>
+        <%= render partial: 'theme', locals: { theme: theme, show_like_button: false } %>
       <% end %>
 
       <div class="d-flex justify-content-center mt-4">

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -12,6 +12,16 @@
           <p class="text-muted"><%= @theme.description %></p>
         </div>
 
+        <div class="d-flex justify-content-end mt-3">
+          <% if @show_like_button %>
+            <%= render 'shared/like_button', likeable: @theme %>
+          <% else %>
+            <div class="likes-count text-muted">
+              <i class="far fa-heart"></i> <%= @theme.likes_count %>
+            </div>
+          <% end %>
+        </div>
+
         <% if @first_post.present? %>
           <div class="mt-4">
             <h2 class="h4 mb-4"><%= @first_post.user == current_user ? "最初に自分が詠んだ句" : "最初に詠まれた句" %></h2>

--- a/app/views/users/themes.html.erb
+++ b/app/views/users/themes.html.erb
@@ -1,4 +1,4 @@
-<div class="container mt-4">
+docker compose run web <div class="container mt-4">
   <div class="row justify-content-center">
     <div class="col-md-8">
       <h2 class="mb-4 h4"><%= @user.name %>さんが作成したお題一覧</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root 'home#index'
-  
+
   get 'signup', to: 'users#new'
   post 'signup', to: 'users#create'
   resources :users, only: [:create] do
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
     member do
       get :all_posts
     end
-    
+
     resources :posts do
       collection do
         get :new_type
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
       end
     end
   end
-  
+
   resource :profile, only: [:show, :edit, :update] do
     get 'password', to: 'profiles#edit_password'
     patch 'password', to: 'profiles#update_password'
@@ -55,7 +55,9 @@ Rails.application.routes.draw do
     delete 'deactivate', to: 'registrations#deactivate'
   end
 
-  # フッター用のルーティング
+  post 'like', to: 'likes#create', as: :like
+  delete 'unlike', to: 'likes#destroy', as: :unlike
+
   get 'about', to: 'pages#about', as: :about
   get 'terms', to: 'pages#terms', as: :terms
   get 'privacy', to: 'pages#privacy', as: :privacy

--- a/db/migrate/20240121000000_create_likes.rb
+++ b/db/migrate/20240121000000_create_likes.rb
@@ -1,0 +1,14 @@
+class CreateLikes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :likeable, polymorphic: true, null: false
+      t.timestamps
+    end
+
+    add_index :likes, [:user_id, :likeable_type, :likeable_id], unique: true
+    
+    add_column :posts, :likes_count, :integer, default: 0
+    add_column :themes, :likes_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20250122023442_add_default_to_likes_count.rb
+++ b/db/migrate/20250122023442_add_default_to_likes_count.rb
@@ -1,0 +1,17 @@
+class AddDefaultToLikesCount < ActiveRecord::Migration[7.0]
+  def up
+    change_column_default :posts, :likes_count, from: nil, to: 0
+    change_column_default :themes, :likes_count, from: nil, to: 0
+
+    # 既存のレコードのlikes_countがnilの場合は0に更新
+    execute <<-SQL
+      UPDATE posts SET likes_count = 0 WHERE likes_count IS NULL;
+      UPDATE themes SET likes_count = 0 WHERE likes_count IS NULL;
+    SQL
+  end
+
+  def down
+    change_column_default :posts, :likes_count, from: 0, to: nil
+    change_column_default :themes, :likes_count, from: 0, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_15_001521) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_22_023442) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,17 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_15_001521) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "likeable_type", null: false
+    t.bigint "likeable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["likeable_type", "likeable_id"], name: "index_likes_on_likeable"
+    t.index ["user_id", "likeable_type", "likeable_id"], name: "index_likes_on_user_id_and_likeable_type_and_likeable_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "post_tags", force: :cascade do |t|
     t.bigint "post_id", null: false
     t.bigint "tag_id", null: false
@@ -66,6 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_15_001521) do
     t.string "reading", default: "", null: false
     t.bigint "image_post_id"
     t.bigint "theme_id"
+    t.integer "likes_count", default: 0
     t.index ["image_post_id"], name: "index_posts_on_image_post_id"
     t.index ["theme_id"], name: "index_posts_on_theme_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
@@ -85,6 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_15_001521) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "image_post_id"
+    t.integer "likes_count", default: 0
     t.index ["image_post_id"], name: "index_themes_on_image_post_id"
     t.index ["user_id"], name: "index_themes_on_user_id"
   end
@@ -103,6 +116,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_15_001521) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "likes", "users"
   add_foreign_key "post_tags", "posts"
   add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "image_posts"

--- a/lib/tasks/fix_posts_themes.rake
+++ b/lib/tasks/fix_posts_themes.rake
@@ -1,0 +1,18 @@
+namespace :posts do
+  desc "Fix posts without themes"
+  task fix_themes: :environment do
+    Post.includes(:theme, :image_post).find_each do |post|
+      next if post.theme.present? || !post.image_post.present?
+
+      # 既存のお題を探すか、新しく作成
+      theme = post.image_post.themes.first_or_create! do |t|
+        t.user = post.user
+        t.description = post.image_post.description
+        t.image.attach(post.image_post.image.blob) if post.image_post.image.attached?
+      end
+
+      post.update!(theme: theme)
+      puts "Fixed post ID: #{post.id} with theme ID: #{theme.id}"
+    end
+  end
+end

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class LikeTest < ActiveSupport::TestCase
+  def setup
+    @user = users(:one)
+    @post = posts(:one)
+    @theme = themes(:one)
+    @like = Like.new(user: @user, likeable: @post)
+  end
+
+  test "should be valid" do
+    assert @like.valid?
+  end
+
+  test "should require a user" do
+    @like.user = nil
+    assert_not @like.valid?
+  end
+
+  test "should require a likeable" do
+    @like.likeable = nil
+    assert_not @like.valid?
+  end
+
+  test "should not allow duplicate likes" do
+    @like.save
+    duplicate_like = @like.dup
+    assert_not duplicate_like.valid?
+  end
+
+  test "should not allow user to like their own content" do
+    own_post = Post.create!(
+      user: @user,
+      reading: "てすと",
+      display_content: "テスト"
+    )
+    like = Like.new(user: @user, likeable: own_post)
+    assert_not like.valid?
+  end
+end


### PR DESCRIPTION
# いいね機能の実装とUIの改善

## 概要
句とお題へのいいね機能を実装しました。
また、いいね表示のレイアウトを一覧画面と詳細画面で統一しました。

## 実装内容
### いいね機能
- 句とお題へのいいね追加・削除機能
- いいねの状態に応じたハートアイコンの表示
- いいね数のカウント表示

### デザイン統一
- ハートアイコンといいね数の配置を統一（左：ハート、右：数字）
- 一覧画面と詳細画面でのデザイン統一
- 一貫した間隔（gap-2）の適用

### その他の改善
- お題削除時の外部キー制約エラーを修正

## 動作確認項目
1. [x] いいね機能の基本動作
   - いいねの追加・削除
   - いいね数のカウント
   - 自分の投稿へのいいね制限
2. [x] いいね表示の一貫性
   - 一覧画面での表示
   - 詳細画面での表示
   - レスポンシブ対応
3. [x] お題の削除機能
   - 関連する投稿がある場合の削除
   - エラーハンドリング

## 技術的変更点
- Likeモデルのポリモーフィック関連付け
- counter_cacheによるいいね数の管理
- トランザクションを使用したお題削除処理の改善

## テスト実施内容
- いいね機能の動作確認
- レイアウトの一貫性確認
- お題削除機能の確認
- 各画面でのレスポンシブ動作確認

## 影響範囲
- 句の一覧・詳細表示
- お題の一覧・詳細表示
- フッターのデザイン
- お題の削除機能

## 補足事項
- プロフィール画面でのいいねした句・お題の一覧表示は次回のブランチで実装予定です
- いいねの通知機能は今後の追加機能として検討中です