### PR TITLE
いいねした一覧

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,6 +5,13 @@ class ProfilesController < ApplicationController
     begin
       @user = current_user
       @posts = @user.posts.includes(:tags, :image_post).order(created_at: :desc)
+      @liked_posts = Post.joins(:likes)
+                      .includes(:tags, :image_post)
+                      .where(likes: { user_id: @user.id })
+                      .order('likes.created_at DESC')
+                      @liked_themes = Theme.joins(:likes)
+                      .where(likes: { user_id: @user.id })
+                      .order('likes.created_at DESC')
       @image_post = ImagePost.find_by(id: session[:image_post_id]) if session[:image_post_id]
       @show_like_button = false
     rescue => e

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,24 @@ class UsersController < ApplicationController
     @themes = @user.themes.order(created_at: :desc).page(params[:page])
   end
 
+  def liked_posts
+    @user = User.find(params[:id])
+    @posts = @user.likes.where(likeable_type: 'Post')
+                      .includes(likeable: [:tags, :image_post])
+                      .order(created_at: :desc)
+                      .map(&:likeable)
+    @show_like_button = true
+  end
+
+  def liked_themes
+    @user = User.find(params[:id])
+    @themes = @user.likes.where(likeable_type: 'Theme')
+                      .includes(:likeable)
+                      .order(created_at: :desc)
+                      .map(&:likeable)
+    @show_like_button = true
+  end
+
   private
 
   def user_params

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -27,7 +27,7 @@
       </div>
     </div>
 
-    <div>
+    <div class="mb-4">
       <div class="d-flex justify-content-between align-items-center mb-3">
         <h3 class="h5 mb-0">投稿した句一覧</h3>
         <%= link_to "すべての句を見る (#{@posts.count})", posts_user_path(@user.id),
@@ -56,6 +56,38 @@
         <%= render partial: 'themes/theme', collection: @user.themes.order(created_at: :desc).limit(3), locals: { show_like_button: false } %>
       <% else %>
         <p class="text-center text-muted">まだお題を作成していません</p>
+      <% end %>
+    </div>
+
+    <div class="mb-4">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h3 class="h5 mb-0">いいねした句一覧</h3>
+        <%= link_to "すべての句を見る (#{@liked_posts.count})", liked_posts_user_path(@user.id),
+            class: "text-decoration-none" %>
+      </div>
+
+      <% if @liked_posts.exists? %>
+        <div class="grid gap-4">
+          <% @liked_posts.limit(3).each do |post| %>
+            <%= render partial: 'posts/post', locals: { post: post, show_like_button: false } %>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="text-center text-muted">まだいいねした句はありません</p>
+      <% end %>
+    </div>
+
+    <div class="mb-4">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h3 class="h5 mb-0">いいねしたお題一覧</h3>
+        <%= link_to "すべてのお題を見る (#{@liked_themes.count})", liked_themes_user_path(@user.id),
+            class: "text-decoration-none" %>
+      </div>
+
+      <% if @liked_themes.exists? %>
+        <%= render partial: 'themes/theme', collection: @liked_themes.limit(3), locals: { show_like_button: false } %>
+      <% else %>
+        <p class="text-center text-muted">まだいいねしたお題はありません</p>
       <% end %>
     </div>
 

--- a/app/views/users/liked_posts.html.erb
+++ b/app/views/users/liked_posts.html.erb
@@ -1,0 +1,15 @@
+<% content_for :with_direction_toggle, true %>
+
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <h2 class="mb-4 h4">いいねした句一覧</h2>
+
+    <% if @posts.present? %>
+      <div class="grid gap-4">
+        <%= render partial: 'posts/post', collection: @posts, locals: { show_like_button: @show_like_button } %>
+      </div>
+    <% else %>
+      <p class="text-center text-muted">まだいいねした句はありません</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/liked_themes.html.erb
+++ b/app/views/users/liked_themes.html.erb
@@ -1,0 +1,13 @@
+<% content_for :with_direction_toggle, true %>
+
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <h2 class="mb-4 h4">いいねしたお題一覧</h2>
+
+    <% if @themes.present? %>
+      <%= render @themes, show_like_button: @show_like_button %>
+    <% else %>
+      <p class="text-center text-muted">まだいいねしたお題はありません</p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
     member do
       get 'posts'
       get 'themes'
+      get 'liked_posts'
+      get 'liked_themes'
     end
   end
 

--- a/db/migrate/20250123035308_add_indices_for_likes.rb
+++ b/db/migrate/20250123035308_add_indices_for_likes.rb
@@ -1,0 +1,6 @@
+class AddIndicesForLikes < ActiveRecord::Migration[7.0]
+  def change
+    add_index :likes, [:user_id, :likeable_type]
+    add_index :likes, [:likeable_type, :likeable_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_22_023442) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_23_035308) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,7 +55,9 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_22_023442) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["likeable_type", "likeable_id"], name: "index_likes_on_likeable"
+    t.index ["likeable_type", "likeable_id"], name: "index_likes_on_likeable_type_and_likeable_id"
     t.index ["user_id", "likeable_type", "likeable_id"], name: "index_likes_on_user_id_and_likeable_type_and_likeable_id", unique: true
+    t.index ["user_id", "likeable_type"], name: "index_likes_on_user_id_and_likeable_type"
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 


### PR DESCRIPTION
# プロフィール画面の機能拡張とパフォーマンス改善

## 概要
プロフィール画面にいいねした句・お題の一覧を追加し、既存の投稿一覧のレイアウトを改善しました。
また、いいね機能のパフォーマンス向上のためにインデックスを追加しました。

## 実装内容
### プロフィール画面の改善
- 投稿した句・お題の表示を最新3件に制限
- いいねした句・お題の一覧を追加（各3件まで表示）
- 各セクションの「すべて見る」リンクを追加

### いいね一覧機能の追加
- いいねした句の一覧ページを追加
- いいねしたお題の一覧ページを追加
- 一覧表示のいいねボタン制御

### パフォーマンス改善
- Likesテーブルにインデックスを追加
  - user_idとlikeable_typeの複合インデックス
  - likeable_typeとlikeable_idの複合インデックス

## 動作確認項目
1. [x] プロフィール画面の表示
   - 投稿した句・お題の表示（最新3件）
   - いいねした句・お題の表示（最新3件）
   - 各「すべて見る」リンクの動作
2. [x] いいね一覧ページの動作
   - いいねした句一覧の表示
   - いいねしたお題一覧の表示
   - いいねボタンの表示制御
3. [x] データの取得
   - 必要なデータが正しく取得できている
   - N+1問題が発生していない

## 技術的変更点
- ActiveRecord::Relationを使用したクエリの最適化
- 複合インデックスによるクエリパフォーマンスの改善
- いいね関連のルーティング追加

## テスト実施内容
- プロフィール画面の表示確認
- いいね一覧画面の表示確認
- いいねボタンの動作確認
- データ取得のパフォーマンス確認

## 影響範囲
- プロフィール画面
- ユーザー関連の一覧表示
- いいね機能のパフォーマンス

## 補足事項
- 今後の機能追加時（並び替えやページネーション）のために、インデックスを先行して追加しています
- パフォーマンスの影響は現時点では限定的ですが、データ量が増えた際に効果を発揮します