### PR TITLE
字余りと字足らず

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -21,13 +21,14 @@ class Post < ApplicationRecord
   validate :validate_reading_spaces
   validate :validate_display_content_newlines
 
+  after_save :check_syllable_count_tags
   after_destroy :destroy_orphaned_image_post
 
 
 
   def reading_validation
     return if reading.blank?
-    
+
     unless reading.match?(/\A[ぁ-んァ-ン゛゜ー・　\s]*\z/)
       errors.add(:reading, :kana_only_reading)
       return
@@ -46,7 +47,7 @@ class Post < ApplicationRecord
 
     reading_length = reading.gsub(/[\s　]/,'').length
     content_length = display_content.gsub(/[\s　]/,'').length
-    
+
     if content_length < (reading_length / 2)
       errors.add(:base, "本文が読みと比べて短すぎるようです")
     elsif content_length > (reading_length * 2)
@@ -56,12 +57,12 @@ class Post < ApplicationRecord
 
   def count_syllables(text)
     return 0 if text.blank?
-    
+
     text = text.tr('ァ-ン', 'ぁ-ん')
     chars = text.chars
     count = 0
     i = 0
-    
+
     while i < chars.length
       case chars[i]
       when /[あ-ん]/
@@ -85,10 +86,10 @@ class Post < ApplicationRecord
       end
       i += 1
     end
-    
+
     count
   end
-  
+
   private
 
   def tag_presence_validation
@@ -102,7 +103,7 @@ class Post < ApplicationRecord
   def validate_reading_spaces
     # 全角空白を半角空白に統一
     normalized_reading = reading.gsub('　', ' ')
-    
+
     # 連続した空白のチェック
     if normalized_reading.match?(/\s{2,}/)
       errors.add(:reading, "空白は連続して入力できません")
@@ -111,7 +112,7 @@ class Post < ApplicationRecord
 
     # 空白文字数のカウント
     space_count = normalized_reading.count(' ')
-    
+
     unless (1..2).include?(space_count)
       errors.add(:reading, "句全体で1つまたは2つの空白を入れてください")
     end
@@ -119,22 +120,22 @@ class Post < ApplicationRecord
 
   def validate_display_content_newlines
     return if display_content.blank?
-  
+
     # 改行の数をカウント
     newline_count = display_content.count("\n")
-  
+
     # 改行数のバリデーション（1以上2以下）
     if newline_count < 1
       errors.add(:display_content, "句全体で1つまたは2つの改行を入れてください")
     elsif newline_count > 2
       errors.add(:display_content, "3つ以上の改行は入力できません")
     end
-  
+
     # 本文の最初と最後に改行がないかチェック
     if display_content.start_with?("\n") || display_content.end_with?("\n")
       errors.add(:display_content, "句の最初と最後に改行を入れることはできません")
     end
-  
+
     # 連続した改行がないかチェック
     if display_content.match?(/\n\n/)
       errors.add(:display_content, "連続した改行は入力できません")
@@ -144,6 +145,23 @@ class Post < ApplicationRecord
   def destroy_orphaned_image_post
     if image_post && image_post.posts.empty?
       image_post.destroy
+    end
+  end
+
+  def check_syllable_count_tags
+    # 既存の字足らず・字余りタグを削除
+    tags.where(name: ['字足らず', '字余り']).each do |tag|
+      post_tags.find_by(tag: tag)&.destroy
+    end
+
+    # 音数を計算（既存のcount_syllablesメソッドを使用）
+    syllables = count_syllables(reading)
+
+    # タグを付与
+    if syllables < 17
+      tags << Tag.find_by(name: '字足らず')
+    elsif syllables > 17
+      tags << Tag.find_by(name: '字余り')
     end
   end
 end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -15,13 +15,21 @@
         </div>
       <% end %>
       <div class="d-flex justify-content-between align-items-start mb-3">
-        <span class="badge bg-primary"><%= post.tags.first&.name %></span>
+        <div>
+          <% post.tags.each do |tag| %>
+            <% if ['俳句', '川柳'].include?(tag.name) %>
+              <span class="badge bg-primary me-1"><%= tag.name %></span>
+            <% else %>
+              <span class="badge bg-secondary me-1"><%= tag.name %></span>
+            <% end %>
+          <% end %>
+        </div>
         <small class="text-muted"><%= l post.created_at, format: :long %></small>
       </div>
       <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
     </div>
   <% end %>
-  
+
   <div class="card-footer bg-transparent">
     <div class="d-flex justify-content-end">
       <%= render 'shared/like_count', likeable: post %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,7 +25,13 @@
 
           <div class="d-flex justify-content-between align-items-start mt-3">
             <div>
-              <span class="badge bg-primary me-1"><%= @post.tags.first&.name %></span>
+              <% @post.tags.each do |tag| %>
+                <% if ['俳句', '川柳'].include?(tag.name) %>
+                  <span class="badge bg-primary me-1"><%= tag.name %></span>
+                <% else %>
+                  <span class="badge bg-secondary me-1"><%= tag.name %></span>
+                <% end %>
+              <% end %>
             </div>
             <small class="text-muted"><%= l @post.created_at, format: :long %></small>
           </div>
@@ -45,8 +51,8 @@
 
         <% if logged_in? && current_user == @post.user %>
           <div class="mt-3">
-            <%= button_to '削除', post_path(@post), 
-                method: :delete, 
+            <%= button_to '削除', post_path(@post),
+                method: :delete,
                 form: { data: { turbo_confirm: '本当に削除してもよろしいですか？' } },
                 class: 'button button-danger' %>
           </div>

--- a/app/views/themes/all_posts.html.erb
+++ b/app/views/themes/all_posts.html.erb
@@ -1,38 +1,60 @@
 <% content_for :with_direction_toggle, true %>
 
-
-
-<% if @theme.image.attached? %>
-  <div class="text-center mb-4">
-    <%= image_tag @theme.display_image, class: "rounded" %>
-    <p class="mt-2"><%= @theme.description %></p>
-  </div>
-<% end %>
-
-<h2 class="text-center mb-4">このお題で詠まれた句 （<%= @posts.total_count %>件）</h2>
-
-<% if @posts.any? %>
-  <% @posts.each do |post| %>
-    <div class="card mb-4">
-      <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
-        <div class="card-body">
-          <div class="d-flex justify-content-between align-items-start mb-2">
-            <span class="badge bg-primary"><%= post.tags.first&.name %></span>
-            <small class="text-muted"><%= l post.created_at, format: :long %></small>
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <div class="card mb-3">
+      <div class="card-body">
+        <% if @theme.image.attached? %>
+          <div class="text-center mb-4">
+            <%= image_tag @theme.display_image, class: "rounded" %>
+            <p class="mt-2 mb-0"><%= @theme.description %></p>
           </div>
-          <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
+        <% end %>
+
+        <h2 class="text-center h4 mb-4">このお題で詠まれた句 （<%= @posts.total_count %>件）</h2>
+
+        <% if @posts.any? %>
+          <div class="mt-4">
+            <% @posts.each do |post| %>
+              <div class="card mb-3">
+                <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
+                  <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-start mb-3">
+                      <div>
+                        <% post.tags.each do |tag| %>
+                          <% if ['俳句', '川柳'].include?(tag.name) %>
+                            <span class="badge bg-primary me-1"><%= tag.name %></span>
+                          <% else %>
+                            <span class="badge bg-secondary me-1"><%= tag.name %></span>
+                          <% end %>
+                        <% end %>
+                      </div>
+                      <small class="text-muted"><%= l post.created_at, format: :long %></small>
+                    </div>
+                    <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
+                  </div>
+                <% end %>
+
+                <div class="card-footer bg-transparent">
+                  <div class="d-flex justify-content-end">
+                    <%= render 'shared/like_count', likeable: post %>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+
+            <div class="mt-4">
+              <%= paginate @posts %>
+            </div>
+          </div>
+        <% else %>
+          <p class="text-center text-muted">まだ句が詠まれていません</p>
+        <% end %>
+
+        <div class="text-center mt-4">
+          <%= render 'shared/back_button', fallback_path: theme_path(@theme) %>
         </div>
-      <% end %>
+      </div>
     </div>
-  <% end %>
-
-  <div class="mt-4">
-    <%= paginate @posts %>
   </div>
-<% else %>
-  <p class="text-center text-muted">まだ句が詠まれていません</p>
-<% end %>
-
-<div class="text-center mt-4">
-  <%= link_to '戻る', 'javascript:history.back()', class: 'text-decoration-none' %>
 </div>

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -30,7 +30,13 @@
                 <div class="card-body">
                   <div class="d-flex justify-content-between align-items-start mb-2">
                     <div class="tags">
-                      <span class="badge bg-primary me-1"><%= @first_post.tags.first&.name %></span>
+                      <% @first_post.tags.each do |tag| %>
+                        <% if ['俳句', '川柳'].include?(tag.name) %>
+                          <span class="badge bg-primary me-1"><%= tag.name %></span>
+                        <% else %>
+                          <span class="badge bg-secondary me-1"><%= tag.name %></span>
+                        <% end %>
+                      <% end %>
                     </div>
                     <small class="text-muted"><%= l @first_post.created_at, format: :long %></small>
                   </div>
@@ -49,7 +55,13 @@
                 <div class="card-body">
                   <div class="d-flex justify-content-between align-items-start mb-2">
                     <div class="tags">
-                      <span class="badge bg-primary me-1"><%= @my_post.tags.first&.name %></span>
+                      <% @my_post.tags.each do |tag| %>
+                        <% if ['俳句', '川柳'].include?(tag.name) %>
+                          <span class="badge bg-primary me-1"><%= tag.name %></span>
+                        <% else %>
+                          <span class="badge bg-secondary me-1"><%= tag.name %></span>
+                        <% end %>
+                      <% end %>
                     </div>
                     <small class="text-muted"><%= l @my_post.created_at, format: :long %></small>
                   </div>
@@ -70,7 +82,13 @@
                     <div class="card-body">
                       <div class="d-flex justify-content-between align-items-start mb-2">
                         <div class="tags">
-                          <span class="badge bg-primary me-1"><%= post.tags.first&.name %></span>
+                          <% post.tags.each do |tag| %>
+                            <% if ['俳句', '川柳'].include?(tag.name) %>
+                              <span class="badge bg-primary me-1"><%= tag.name %></span>
+                            <% else %>
+                              <span class="badge bg-secondary me-1"><%= tag.name %></span>
+                            <% end %>
+                          <% end %>
                         </div>
                         <small class="text-muted"><%= l post.created_at, format: :long %></small>
                       </div>

--- a/app/views/users/posts.html.erb
+++ b/app/views/users/posts.html.erb
@@ -19,7 +19,15 @@
                   </div>
                 <% end %>
                 <div class="d-flex justify-content-between align-items-start mb-3">
-                  <span class="badge bg-primary"><%= post.tags.first&.name %></span>
+                  <div>
+                    <% post.tags.each do |tag| %>
+                      <% if ['俳句', '川柳'].include?(tag.name) %>
+                        <span class="badge bg-primary me-1"><%= tag.name %></span>
+                      <% else %>
+                        <span class="badge bg-secondary me-1"><%= tag.name %></span>
+                      <% end %>
+                    <% end %>
+                  </div>
                   <small class="text-muted"><%= l post.created_at, format: :long %></small>
                 </div>
                 <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>

--- a/db/migrate/20250123044528_add_syllable_count_tags.rb
+++ b/db/migrate/20250123044528_add_syllable_count_tags.rb
@@ -1,0 +1,15 @@
+class AddSyllableCountTags < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        ['字足らず', '字余り'].each do |name|
+          Tag.create!(name: name)
+        end
+      end
+
+      dir.down do
+        Tag.where(name: ['字足らず', '字余り']).destroy_all
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_23_035308) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_23_044528) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/lib/tasks/posts.rake
+++ b/lib/tasks/posts.rake
@@ -1,0 +1,15 @@
+namespace :posts do
+  desc "Update syllable count tags for existing posts"
+  task update_syllable_tags: :environment do
+    puts "Updating syllable count tags for existing posts..."
+
+    Post.find_each.with_index do |post, index|
+      post.send(:check_syllable_count_tags)
+      if (index + 1) % 100 == 0
+        puts "Processed #{index + 1} posts"
+      end
+    end
+
+    puts "Completed updating syllable count tags!"
+  end
+end


### PR DESCRIPTION
# 句の音数に基づくタグ機能の追加とデザイン統一

## 概要
句の音数（17音）に基づいて「字足らず」「字余り」のタグを自動付与する機能を追加し、
全画面でのタグ表示とデザインを統一しました。

## 実装内容
### タグ機能の追加
- 「字足らず」タグ（17音未満）の自動付与
- 「字余り」タグ（17音超過）の自動付与
- 既存の投稿への遡及適用機能

### タグ表示の改善
- 俳句・川柳タグを青色で表示
- 字足らず・字余りタグを灰色で表示
- すべての一覧画面でタグ表示を統一

### デザインの統一
- お題の句一覧画面のデザインを他の画面と統一
- カードベースのレイアウトに統一
- 余白や配置の一貫性を確保

## 動作確認項目
1. [x] タグの自動付与
   - 17音未満の句に「字足らず」タグが付く
   - 17音を超える句に「字余り」タグが付く
   - 17音ちょうどの句にはどちらのタグも付かない

2. [x] タグの表示
   - すべての一覧画面でタグが正しく表示される
   - タグの色分けが適切（俳句・川柳は青、字足らず・字余りは灰色）
   - タグの配置が適切

3. [x] 画面表示の一貫性
   - 句一覧画面
   - お題詳細画面
   - ユーザー投稿一覧画面
   - いいねした句一覧画面
   - お題の句一覧画面

## 技術的変更点
- Post モデルに音数チェックのコールバックを追加
- マイグレーションによる新規タグの追加
- ビューテンプレートの共通化によるデザインの統一

## テスト実施内容
- 新規投稿時のタグ自動付与の確認
- 既存投稿へのタグ付与の確認
- 各画面でのタグ表示確認
- レイアウトの一貫性確認

## 影響範囲
- 投稿機能
- タグ機能
- 一覧表示のデザイン

## 補足事項
- 既存の投稿にもタグを適用するためのRakeタスクを用意しています
- デザインの統一により、今後の機能追加時の一貫性が確保されます