### PR TITLE
ヘッダーパーシャルの適用

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,29 +13,7 @@
   </head>
 
   <body class="d-flex flex-column min-vh-100">
-    <header class="header">
-      <div class="header-container">
-        <div class="header-left">
-          <%= link_to 'ホーム', root_path, class: 'button' %>
-          <% if logged_in? %>
-            <%= link_to '句一覧', posts_path, class: 'button' %>
-            <%= link_to 'お題一覧', themes_path, class: 'button' %>
-          <% end %>
-        </div>
-
-        <div class="header-right">
-          <% if logged_in? %>
-            <%= link_to profile_path, class: 'text-decoration-none text-dark' do %>
-              <span class="fw-medium"><%= current_user.name %></span>
-            <% end %>
-            <%= link_to '句を詠む', new_image_post_path, class: 'button button-success ms-3' %>
-          <% else %>
-            <%= link_to 'ログイン', login_path, class: 'button' %>
-            <%= link_to '新規登録', signup_path, class: 'button' %>
-          <% end %>
-        </div>
-      </div>
-    </header>
+    <%= render 'shared/header' %>
 
     <% if flash.any? %>
       <div class="alert-wrapper">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="header">
-  <div class="header-content">
+  <div class="header-container">
     <div class="header-left">
       <%= link_to 'ホーム', root_path, class: 'button' %>
       <% if logged_in? %>


### PR DESCRIPTION
Copy# ヘッダーのパーシャル化とビューの整理

## 概要
アプリケーション全体のビューコードを整理し、ヘッダー部分をパーシャル化することで、
コードの重複を削減し、メンテナンス性を向上させました。

## 実装内容
### ヘッダーのパーシャル化
- `application.html.erb`のヘッダー部分を`_header.html.erb`パーシャルに移行
- ヘッダーのマークアップ構造とクラス名の統一
- 共通レイアウトの整理

### パーシャルの使用状況整理
- `_like_count.html.erb`の使用箇所を確認・整理
- `_post.html.erb`と`_theme.html.erb`の使用状況を確認
- 各パーシャルの役割を明確化

## 動作確認項目
1. [x] ヘッダーの表示
   - ログイン前の表示確認
   - ログイン後の表示確認
   - レスポンシブ対応の確認
   - 各ボタンの配置と動作確認

2. [x] 既存機能への影響確認
   - ナビゲーションの動作
   - ユーザー名の表示
   - 「句を詠む」ボタンの配置と動作
   - ログイン/新規登録リンクの表示

3. [x] レイアウトの一貫性
   - 全画面でのヘッダー表示の統一
   - モバイル表示での動作確認
   - スタイリングの一貫性確認

## 技術的変更点
- `application.html.erb`からヘッダーコードを削除
- `shared/_header.html.erb`の活用
- クラス名の統一（`header-container`の使用）

## テスト実施内容
- ヘッダーの表示確認
- レスポンシブ動作の確認
- 各画面での表示一貫性の確認
- ユーザー状態による表示切り替えの確認

## 影響範囲
- アプリケーション全体のレイアウト
- ヘッダーナビゲーション
- レスポンシブデザイン

## 補足事項
- ヘッダーのパーシャル化により、今後のデザイン変更や機能追加が容易になります
- 既存のパーシャル（`_like_count.html.erb`、`_post.html.erb`、`_theme.html.erb`）は
  適切に使用されていることを確認済みです