### PR TITLE
管理画面ダッシュボードとログイン

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,18 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_login
+  before_action :check_admin
+  layout 'admin/application'
+
+  private
+
+  def check_admin
+    unless current_user&.admin?
+      redirect_to root_path, alert: '管理者権限が必要です'
+    end
+  end
+
+  def not_authenticated
+    flash[:warning] = 'ログインしてください'
+    redirect_to admin_login_path
+  end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,13 @@
+class Admin::DashboardController < Admin::BaseController
+  def index
+    @stats = {
+      total_users: User.count,
+      total_posts: Post.count,
+      today_posts: Post.where('created_at >= ?', Time.current.beginning_of_day).count,
+      active_users: User.where('last_login_at >= ?', 30.days.ago).count
+    }
+
+    @recent_users = User.order(created_at: :desc).limit(5)
+    @recent_posts = Post.order(created_at: :desc).limit(5)
+  end
+end

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,0 +1,5 @@
+class Admin::PostsController < Admin::BaseController
+  def index
+    @posts = Post.includes(:user).order(created_at: :desc).page(params[:page])
+  end
+end

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -1,0 +1,23 @@
+class Admin::UserSessionsController < Admin::BaseController
+  skip_before_action :require_login, only: %i[new create]
+  skip_before_action :check_admin, only: %i[new create]
+  layout 'admin/login'
+
+  def new; end
+
+  def create
+    @user = login(params[:email], params[:password])
+    if @user&.admin?
+      @user.update(last_login_at: Time.current)  # ログイン時刻を更新
+      redirect_to admin_root_path, success: 'ログインしました'
+    else
+      flash.now[:danger] = 'ログインに失敗しました'
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    logout
+    redirect_to admin_login_path, status: :see_other, success: 'ログアウトしました'
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,5 @@
+class Admin::UsersController < Admin::BaseController
+  def index
+    @users = User.order(created_at: :desc).page(params[:page])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,4 +9,24 @@ module ApplicationHelper
       capture(&block)
     end
   end
+
+  def page_title(title = '', admin: false)
+    base_title = admin ? 'HITOHI-HITONANA(管理画面)' : 'HITOHI-HITONANA'
+    title.present? ? "#{title} | #{base_title}" : base_title
+  end
+
+  def flash_class(key)
+    case key
+    when 'success'
+      'bg-green-100 border border-green-400 text-green-700'
+    when 'danger'
+      'bg-red-100 border border-red-400 text-red-700'
+    when 'warning'
+      'bg-yellow-100 border border-yellow-400 text-yellow-700'
+    when 'info'
+      'bg-blue-100 border border-blue-400 text-blue-700'
+    else
+      'bg-gray-100 border border-gray-400 text-gray-700'
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true
   validates :name, presence: true
 
+  enum role: { general: 0, admin: 1 }
+
   def likes?(likeable)
     likes.exists?(likeable: likeable)
   end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,63 @@
+<% content_for(:title, 'ダッシュボード') %>
+
+<div class="mb-4">
+  <h1 class="h3">ダッシュボード</h1>
+</div>
+
+<div class="row mb-4">
+  <div class="col-md-4">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">総ユーザー数</h5>
+        <p class="card-text h2"><%= @stats[:total_users] %></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">総投稿数</h5>
+        <p class="card-text h2"><%= @stats[:total_posts] %></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">本日の投稿数</h5>
+        <p class="card-text h2"><%= @stats[:today_posts] %></p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6 mb-4">
+    <div class="card">
+      <div class="card-header">
+        <h5 class="card-title mb-0">最近の登録ユーザー</h5>
+      </div>
+      <div class="list-group list-group-flush">
+        <%= render partial: 'admin/users/user', collection: @recent_users %>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-6 mb-4">
+    <div class="card">
+      <div class="card-header">
+        <h5 class="card-title mb-0">最近の投稿</h5>
+      </div>
+      <div class="list-group list-group-flush">
+        <% @recent_posts.each do |post| %>
+          <div class="list-group-item">
+            <p class="mb-1"><%= post.display_content %></p>
+            <small class="text-muted">
+              <%= post.user.name %> - <%= l post.created_at, format: :long %>
+            </small>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -1,0 +1,12 @@
+<header class="header">
+  <div class="header-container">
+    <div class="header-left">
+      <%= link_to '管理画面', admin_root_path, class: 'button' %>
+    </div>
+
+    <div class="header-right">
+      <span class="fw-medium me-3"><%= current_user.email %></span>
+      <%= button_to 'ログアウト', admin_logout_path, method: :delete, class: 'button', data: { turbo: false } %>
+    </div>
+  </div>
+</header>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -1,0 +1,18 @@
+<div class="card">
+  <div class="list-group list-group-flush">
+    <%= link_to admin_root_path,
+        class: "list-group-item list-group-item-action #{current_page?(admin_root_path) ? 'active' : ''}" do %>
+      ダッシュボード
+    <% end %>
+
+    <%= link_to '#',
+        class: "list-group-item list-group-item-action" do %>
+      ユーザー管理
+    <% end %>
+
+    <%= link_to '#',
+        class: "list-group-item list-group-item-action" do %>
+      投稿管理
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/user_sessions/new.html.erb
+++ b/app/views/admin/user_sessions/new.html.erb
@@ -1,0 +1,17 @@
+<div class="bg-white py-8 px-6 shadow rounded-lg">
+  <h2 class="mb-6 text-center text-2xl font-bold text-gray-900">管理画面ログイン</h2>
+
+  <%= form_with url: admin_login_path, local: true, data: { turbo: false }, class: "space-y-6" do |f| %>
+    <div>
+      <%= f.label :email, 'メールアドレス', class: "block text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+    </div>
+
+    <div>
+      <%= f.label :password, 'パスワード', class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+    </div>
+
+    <%= f.submit 'ログイン', class: "w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+  <% end %>
+</div>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -1,0 +1,11 @@
+<div class="flex items-center justify-between py-3">
+  <div class="flex items-center">
+    <div>
+      <p class="font-medium text-gray-900"><%= user.name %></p>
+      <p class="text-sm text-gray-500"><%= user.email %></p>
+    </div>
+  </div>
+  <div class="text-sm text-gray-500">
+    <%= l user.created_at, format: :long %>
+  </div>
+</div>

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= page_title(yield(:title), admin: true) %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+  </head>
+
+  <body class="d-flex flex-column min-vh-100">
+    <%= render 'admin/shared/header' %>
+
+    <% if flash.any? %>
+      <div class="alert-wrapper">
+        <% flash.each do |key, value| %>
+          <div class="alert alert-<%= key == 'notice' ? 'success' : 'danger' %> text-center">
+            <%= value %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
+    <main class="flex-grow-1">
+      <div class="container py-4">
+        <div class="row">
+          <div class="col-md-3">
+            <%= render 'admin/shared/sidebar' %>
+          </div>
+          <div class="col-md-9">
+            <%= yield %>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <footer class="footer mt-auto">
+      <%= render 'shared/footer' %>
+    </footer>
+  </body>
+</html>

--- a/app/views/layouts/admin/login.html.erb
+++ b/app/views/layouts/admin/login.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>管理画面 | <%= Rails.application.class.module_parent_name %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+  </head>
+
+  <body class="bg-gray-50">
+    <div class="min-h-screen flex items-center justify-center">
+      <div class="w-full max-w-md">
+        <%= render 'shared/flash_message' if flash.present? %>
+        <%= yield %>
+      </div>
+    </div>
+  </body>
+</html>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,11 @@
+<% flash.each do |key, value| %>
+  <div class="<%= flash_class(key) %> px-4 py-3 rounded relative mb-4" role="alert">
+    <span class="block sm:inline"><%= value %></span>
+    <button data-dismiss="alert" class="absolute top-0 bottom-0 right-0 px-4 py-3">
+      <span class="sr-only">閉じる</span>
+      <svg class="fill-current h-6 w-6" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+        <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/>
+      </svg>
+    </button>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,14 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    get 'login' => 'user_sessions#new', as: :login
+    post 'login' => 'user_sessions#create'
+    delete 'logout' => 'user_sessions#destroy', as: :logout
+    root 'dashboard#index'
+
+    resources :users, only: [:index, :edit, :update, :destroy]
+    resources :posts, only: [:index, :edit, :update, :destroy]
+  end
+
   root 'home#index'
 
   get 'signup', to: 'users#new'

--- a/db/migrate/20250131080429_add_role_to_users.rb
+++ b/db/migrate/20250131080429_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20250131082550_add_last_login_at_to_users.rb
+++ b/db/migrate/20250131082550_add_last_login_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastLoginAtToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :last_login_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_23_044528) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_31_082550) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -112,6 +112,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_23_044528) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.integer "role", default: 0, null: false
+    t.datetime "last_login_at"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end


### PR DESCRIPTION
# 管理画面の基本実装

## 概要
管理者ユーザーによる管理機能の基盤となる、管理画面へのログインとダッシュボード機能を実装しました。

## 実装内容
### 管理者権限の追加
- Userモデルにroleカラムを追加（enum使用）
- 管理者と一般ユーザーの区別を実装
- ログイン時刻記録機能の追加

### 管理画面の基本機能
- 管理者専用ログイン機能
- ダッシュボード画面の実装
  - 総ユーザー数の表示
  - 総投稿数の表示
  - 本日の投稿数の表示
  - 最近の登録ユーザー一覧
  - 最近の投稿一覧

### 管理画面のUI実装
- 専用レイアウトの作成
- サイドバーナビゲーション
- フラッシュメッセージの実装
- 一般ユーザー画面と統一感のあるデザイン

## 動作確認項目
1. [x] 管理者認証
   - 管理者のみが管理画面にアクセス可能
   - 一般ユーザーはアクセス不可
   - ログアウト機能

2. [x] ダッシュボード機能
   - 各種統計情報の正しい表示
   - 最新情報の表示

3. [x] UI/UX
   - レスポンシブ対応
   - フラッシュメッセージの表示
   - 一般画面との統一感

## 技術的変更点
- Userモデルの拡張（role、last_login_at）
- 管理画面用の名前空間とルーティング設定
- 管理者認証の実装
- 専用レイアウトとビューの作成

## テスト実施内容
- 管理者ログイン/ログアウトの動作確認
- 権限チェックの動作確認
- 統計情報の表示確認
- レスポンシブ動作の確認

## 影響範囲
- ユーザーモデル
- ルーティング設定
- 認証機能

## 補足事項
- 現段階ではダッシュボードの表示とログイン機能のみ実装
- ユーザー管理・投稿管理などの機能は今後のPRで実装予定
- 開発環境では`rails c`で管理者権限の付与が必要