### PR TITLE
投稿とお題の管理

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,5 +1,92 @@
 class Admin::PostsController < Admin::BaseController
+  before_action :set_post, only: [:show, :edit, :update, :destroy, :soft_delete, :restore]
+
   def index
-    @posts = Post.includes(:user).order(created_at: :desc).page(params[:page])
+    @posts = Post.includes(:user, :theme, :likes)
+
+    @posts = case params[:filter]
+            when 'available'
+              @posts.available
+            when 'deleted'
+              @posts.deleted
+            else
+              @posts
+            end
+
+    @posts = @posts.order(created_at: :desc).page(params[:page]).per(20)
+  end
+
+  def show
+  end
+
+  def edit
+    @post = Post.includes(:tags).find(params[:id])
+  end
+
+  def update
+    @post = Post.find(params[:id])
+
+    ActiveRecord::Base.transaction do
+      if params[:post][:tag_id].present?
+        @post.post_tags.destroy_all
+        @post.tags << Tag.find(params[:post][:tag_id])
+      end
+
+      if @post.update(post_params)
+        redirect_to admin_post_path(@post), notice: '句を更新しました'
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+  rescue => e
+    Rails.logger.error "更新エラー: #{e.message}"
+    flash.now[:alert] = '更新できませんでした'
+    render :edit, status: :unprocessable_entity
+  end
+
+  def soft_delete
+    if @post.soft_delete
+      redirect_to admin_post_path(@post), notice: '句を非表示にしました'
+    else
+      flash.now[:alert] = '非表示にできませんでした'
+      render :show
+    end
+  end
+
+  def restore
+    if @post.restore
+      redirect_to admin_post_path(@post), notice: '句を再表示しました'
+    else
+      flash.now[:alert] = '再表示できませんでした'
+      render :show
+    end
+  end
+
+  def destroy
+    begin
+      ActiveRecord::Base.transaction do
+        @post.post_tags.destroy_all
+
+        if @post.image_post.present?
+          @post.update_column(:image_post_id, nil)
+        end
+
+        @post.destroy!
+        redirect_to admin_posts_path, notice: '句を完全に削除しました'
+      end
+    rescue => e
+      logger.error "投稿の削除中にエラーが発生しました: #{e.message}"
+      redirect_to admin_posts_path, alert: '削除中にエラーが発生しました'
+    end
+  end
+
+  private
+
+  def set_post
+    @post = Post.find(params[:id])
+  end
+
+  def post_params
+    params.require(:post).permit(:display_content, :reading)
   end
 end

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -1,0 +1,96 @@
+class Admin::ThemesController < Admin::BaseController
+  before_action :set_theme, only: [:show, :edit, :update, :destroy, :soft_delete, :restore]
+
+  def index
+    @themes = Theme.includes(:user, :posts, :likes)
+
+    @themes = case params[:filter]
+              when 'available'
+                @themes.available
+              when 'deleted'
+                @themes.deleted
+              else
+                @themes
+              end
+
+    @themes = @themes.order(created_at: :desc)
+                    .page(params[:page])
+                    .per(20)
+  end
+
+  def show
+    @theme = Theme.includes(:user, :posts, :likes).find(params[:id])
+    @recent_posts = @theme.posts.includes(:user, :likes)
+                          .order(created_at: :desc)
+                          .limit(5)
+  end
+
+  def new
+    @theme = Theme.new
+  end
+
+  def create
+    @theme = Theme.new(theme_params)
+    if @theme.save
+      redirect_to admin_theme_path(@theme), notice: 'お題を作成しました'
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    begin
+      ActiveRecord::Base.transaction do
+        if params[:remove_image] == '1'
+          @theme.image.purge
+        end
+
+        if @theme.update(theme_params)
+          redirect_to admin_theme_path(@theme), notice: 'お題を更新しました'
+        else
+          render :edit, status: :unprocessable_entity
+        end
+      end
+    rescue => e
+      Rails.logger.error "更新エラー: #{e.message}"
+      flash.now[:alert] = '更新できませんでした'
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def soft_delete
+    if @theme.soft_delete
+      redirect_to admin_theme_path(@theme), notice: 'お題を非表示にしました'
+    else
+      flash.now[:alert] = '非表示にできませんでした'
+      render :show
+    end
+  end
+
+  def restore
+    if @theme.restore
+      redirect_to admin_theme_path(@theme), notice: 'お題を再表示しました'
+    else
+      flash.now[:alert] = '再表示できませんでした'
+      render :show
+    end
+  end
+
+  def destroy
+    @theme.destroy
+    redirect_to admin_themes_path, notice: 'お題を削除しました'
+  end
+
+  private
+
+  def set_theme
+    @theme = Theme.find(params[:id])
+  end
+
+  def theme_params
+    params.require(:theme).permit(:description, :status, :image)
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,11 +15,12 @@ class PostsController < ApplicationController
       Date.today
     end
 
-    @posts = Post.includes(:user, :tags, :image_post, theme: [:posts, :image_attachment])
-                .where(created_at: @date.all_day)
-                .order(created_at: :desc)
-                .page(params[:page])
-                .per(10)
+    @posts = Post.available
+              .includes(:user, :tags, :image_post, theme: [:posts, :image_attachment])
+              .where(created_at: @date.all_day)
+              .order(created_at: :desc)
+              .page(params[:page])
+              .per(10)
 
     @prev_date = @date - 1.day
     @next_date = @date + 1.day

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -4,14 +4,16 @@ class ProfilesController < ApplicationController
   def show
     begin
       @user = current_user
-      @posts = @user.posts.includes(:tags, :image_post).order(created_at: :desc)
-      @liked_posts = Post.joins(:likes)
-                      .includes(:tags, :image_post)
-                      .where(likes: { user_id: @user.id })
-                      .order('likes.created_at DESC')
-                      @liked_themes = Theme.joins(:likes)
-                      .where(likes: { user_id: @user.id })
-                      .order('likes.created_at DESC')
+      @posts = @user.posts.available.includes(:tags, :image_post).order(created_at: :desc)
+      @liked_posts = Post.available
+                    .joins(:likes)
+                    .includes(:tags, :image_post)
+                    .where(likes: { user_id: @user.id })
+                    .order('likes.created_at DESC')
+      @liked_themes = Theme.available
+                    .joins(:likes)
+                    .where(likes: { user_id: @user.id })
+                    .order('likes.created_at DESC')
       @image_post = ImagePost.find_by(id: session[:image_post_id]) if session[:image_post_id]
       @show_like_button = false
     rescue => e

--- a/app/helpers/admin/application_helper.rb
+++ b/app/helpers/admin/application_helper.rb
@@ -1,0 +1,5 @@
+module Admin::ApplicationHelper
+  def active_admin_link?(controller_name)
+    params[:controller].end_with?(controller_name)
+  end
+end

--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.setAttribute("data-turbo", "false")
+  }
+}

--- a/app/models/image_post.rb
+++ b/app/models/image_post.rb
@@ -1,7 +1,6 @@
 class ImagePost < ApplicationRecord
-  has_many :posts
-  has_one :theme
   has_many :posts, dependent: :nullify
+  has_one :theme, dependent: :nullify
   has_one_attached :image
 
   validates :description, length: { maximum: 10 }

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,12 +1,25 @@
 class Theme < ApplicationRecord
   belongs_to :user
-  belongs_to :image_post, optional: true, dependent: :destroy
+  belongs_to :image_post, optional: true
   has_many :posts, dependent: :nullify
   has_one_attached :image
   has_many :likes, as: :likeable, dependent: :destroy
   has_many :users_who_liked, through: :likes, source: :user
 
-  validates :description, presence: true
+  validates :description, presence: { message: "お題を入力してください" }
+  validates :status, presence: { message: "ステータスを選択してください" }
+
+  validate :validate_image_type, if: -> { image.attached? }
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :available, -> { where(deleted_at: nil) }
+  scope :deleted, -> { where.not(deleted_at: nil) }
+
+  enum status: {
+    draft: 0,
+    published: 1,
+    closed: 2
+  }
 
   def posted_by?(user)
     posts.exists?(user_id: user.id)
@@ -27,5 +40,31 @@ class Theme < ApplicationRecord
   def small_image
     return nil unless image.attached?
     image.variant(resize_to_limit: [200, 150])
+  end
+
+  def status
+    'published'
+  end
+
+  def soft_delete
+    update!(deleted_at: Time.current)
+  rescue => e
+    Rails.logger.error "Soft delete failed: #{e.message}"
+    false
+  end
+
+  def restore
+    update!(deleted_at: nil)
+  rescue => e
+    Rails.logger.error "Restore failed: #{e.message}"
+    false
+  end
+
+  private
+
+  def validate_image_type
+    if !image.content_type.in?(%w[image/jpeg image/jpg image/png])
+      errors.add(:image, 'はJPEG、JPG、PNG形式のみ許可されています')
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
   has_many :posts
   has_many :themes
   has_many :likes, dependent: :destroy
+  has_many :visible_posts, -> { available }, class_name: 'Post'
+  has_many :visible_themes, -> { available }, class_name: 'Theme'
   has_many :liked_posts, through: :likes, source: :likeable, source_type: 'Post'
   has_many :liked_themes, through: :likes, source: :likeable, source_type: 'Theme'
 

--- a/app/views/admin/posts/_form.html.erb
+++ b/app/views/admin/posts/_form.html.erb
@@ -1,0 +1,44 @@
+<%= form_with(model: [:admin, post], local: true, data: { turbo: false }) do |f| %>
+  <% if post.errors.any? %>
+    <div class="alert alert-danger">
+      <h4><%= pluralize(post.errors.count, "error") %> が発生しました</h4>
+      <ul>
+        <% post.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-3">
+    <%= f.label :type_tag, "種類", class: "form-label" %>
+    <div>
+      <% current_tag = post.tags.find_by(name: ['俳句', '川柳']) %>
+      <% Tag.where(name: ['俳句', '川柳']).each do |tag| %>
+        <div class="form-check form-check-inline">
+          <%= radio_button_tag 'post[tag_id]', tag.id,
+              tag.id == current_tag&.id,
+              class: "form-check-input",
+              required: true,
+              id: "post_tag_#{tag.id}" %>
+          <%= label_tag "post_tag_#{tag.id}", tag.name, class: "form-check-label" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :display_content, "内容", class: "form-label" %>
+    <%= f.text_area :display_content, class: "form-control", rows: 3 %>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :reading, "読み方", class: "form-label" %>
+    <%= f.text_field :reading, class: "form-control" %>
+  </div>
+
+  <div class="text-end">
+    <%= f.submit "更新", class: "btn btn-primary" %>
+    <%= link_to "戻る", admin_post_path(post), class: "btn btn-secondary ms-2" %>
+  </div>
+<% end %>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -1,0 +1,12 @@
+<div class="container" data-controller="form">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <div class="card">
+        <div class="card-body">
+          <h2 class="card-title mb-4">句の編集</h2>
+          <%= render 'form', post: @post %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,0 +1,77 @@
+<div class="container">
+  <h1 class="text-center mb-4">句の管理</h1>
+
+  <div class="mb-4">
+    <div class="btn-group">
+      <%= link_to '全て', admin_posts_path, class: "btn #{params[:filter].blank? ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <%= link_to '表示中', admin_posts_path(filter: 'available'), class: "btn #{params[:filter] == 'available' ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <%= link_to '非表示', admin_posts_path(filter: 'deleted'), class: "btn #{params[:filter] == 'deleted' ? 'btn-primary' : 'btn-outline-primary'}" %>
+    </div>
+  </div>
+
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <% @posts.each do |post| %>
+        <div class="card mb-3">
+          <div class="card-body">
+            <div class="d-flex justify-content-between align-items-start mb-2">
+
+            <% if post.theme&.image&.attached? %>
+              <div class="me-3" style="width: 100px;">
+                <%= image_tag post.theme.image, class: "img-fluid rounded" %>
+              </div>
+            <% elsif post.image_post&.image&.present? %>
+              <div class="me-3" style="width: 100px;">
+                <%= image_tag post.image_post.image, class: "img-fluid rounded" %>
+              </div>
+            <% end %>
+
+              <div class="tags">
+                <% post.tags.each do |tag| %>
+                  <% if ['俳句', '川柳'].include?(tag.name) %>
+                    <span class="badge bg-primary me-1"><%= tag.name %></span>
+                  <% else %>
+                    <span class="badge bg-secondary me-1"><%= tag.name %></span>
+                  <% end %>
+                <% end %>
+                <%= render 'shared/post_badges', post: post %>
+                <% if post.deleted_at.present? %>
+                  <span class="badge bg-danger me-1">非表示</span>
+                <% else %>
+                  <span class="badge bg-success me-1">表示中</span>
+                <% end %>
+              </div>
+              <small class="text-muted"><%= l post.created_at, format: :long %></small>
+            </div>
+
+            <div class="mb-3">
+              <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
+            </div>
+
+            <div class="d-flex justify-content-between align-items-center">
+              <div class="text-muted">
+                投稿者: <%= post.user.name %>
+              </div>
+              <div class="d-flex align-items-center">
+                <div class="text-muted me-3">
+                  <i class="far fa-heart"></i> <%= post.likes.count %>
+                </div>
+                <%= link_to '詳細', admin_post_path(post), class: 'btn btn-sm btn-outline-primary' %>
+              </div>
+            </div>
+
+            <% if post.theme.present? %>
+              <div class="mt-3 p-3 bg-light rounded">
+                <small class="text-muted">お題：<%= post.theme.description %></small>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <div class="d-flex justify-content-center mt-4">
+        <%= paginate @posts %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/posts/show.html.erb
+++ b/app/views/admin/posts/show.html.erb
@@ -1,0 +1,76 @@
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <div class="card mb-3">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-start mb-3">
+          <div class="tags">
+            <% @post.tags.each do |tag| %>
+              <% if ['俳句', '川柳'].include?(tag.name) %>
+                <span class="badge bg-primary me-1"><%= tag.name %></span>
+              <% else %>
+                <span class="badge bg-secondary me-1"><%= tag.name %></span>
+              <% end %>
+            <% end %>
+            <%= render 'shared/post_badges', post: @post %>
+          </div>
+          <small class="text-muted"><%= l @post.created_at, format: :long %></small>
+        </div>
+
+        <%= render partial: 'posts/post_content', locals: { content: @post.display_content } %>
+
+        <div class="d-flex justify-content-between align-items-center mt-3">
+          <div class="text-muted">
+            投稿者: <%= @post.user.name %>
+          </div>
+          <div class="text-muted">
+            <i class="far fa-heart"></i> <%= @post.likes.count %>
+          </div>
+        </div>
+
+        <% if @post.theme.present? %>
+          <div class="mt-3 p-3 bg-light rounded">
+            <div class="mb-2">
+              <strong>お題：</strong>
+            </div>
+            <% if @post.theme.image.attached? %>
+              <%= image_tag @post.theme.image, class: "w-100 rounded-lg mb-2" %>
+            <% end %>
+            <p class="text-muted mb-0"><%= @post.theme.description %></p>
+          </div>
+        <% end %>
+
+        <div class="mt-4">
+          <div class="btn-group">
+            <%= link_to '編集', edit_admin_post_path(@post), class: 'btn btn-primary' %>
+              <% if @post.deleted_at.present? %>
+                <%= form_with url: restore_admin_post_path(@post),
+                        method: :patch,
+                        local: true,
+                        data: { turbo: false } do |f| %>
+                  <%= f.submit '再表示', class: 'btn btn-success' %>
+                <% end %>
+              <% else %>
+                <%= form_with url: soft_delete_admin_post_path(@post),
+                        method: :patch,
+                        local: true,
+                        data: { turbo: false } do |f| %>
+                  <%= f.submit '非表示', class: 'btn btn-warning' %>
+                <% end %>
+              <% end %>
+              <%= form_with url: admin_post_path(@post),
+                        method: :delete,
+                        local: true,
+                        data: { turbo: false,
+                              confirm: 'この句を完全に削除してもよろしいですか？' } do |f| %>
+                <%= f.submit '完全削除', class: 'btn btn-danger' %>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="mt-4">
+          <%= render 'shared/back_button', fallback_path: admin_posts_path %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -10,9 +10,14 @@
       ユーザー管理
     <% end %>
 
-    <%= link_to '#',
-        class: "list-group-item list-group-item-action" do %>
-      投稿管理
+    <%= link_to admin_posts_path,
+        class: "list-group-item list-group-item-action #{controller_name == 'posts' ? 'active' : ''}" do %>
+      句の管理
+    <% end %>
+
+    <%= link_to admin_themes_path,
+        class: "list-group-item list-group-item-action #{controller_name == 'themes' ? 'active' : ''}" do %>
+      お題の管理
     <% end %>
   </div>
 </div>

--- a/app/views/admin/themes/_form.html.erb
+++ b/app/views/admin/themes/_form.html.erb
@@ -1,0 +1,44 @@
+<%= form_with(model: [:admin, theme], local: true, data: { turbo: false }) do |f| %>
+  <% if theme.errors.any? %>
+    <div class="alert alert-danger">
+      <h4><%= pluralize(theme.errors.count, "error") %> が発生しました</h4>
+      <ul>
+        <% theme.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-3">
+    <%= f.label :description, "お題", class: "form-label" %>
+    <%= f.text_area :description, class: "form-control", rows: 3, required: true %>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :status, "ステータス", class: "form-label" %>
+    <%= f.select :status, Theme.statuses.keys.map { |s| [s.humanize, s] },
+        {}, class: "form-select", required: true %>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :image, "画像", class: "form-label" %>
+    <%= f.file_field :image, class: "form-control", accept: 'image/jpg,image/jpeg,image/png' %>
+    <% if theme.image.attached? %>
+      <div class="mt-2">
+        <div class="card" style="max-width: 200px;">
+          <%= image_tag theme.image, class: "card-img-top" %>
+        </div>
+        <div class="form-check mt-2">
+          <%= check_box_tag :remove_image, '1', false, class: "form-check-input" %>
+          <%= label_tag :remove_image, "画像を削除", class: "form-check-label" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="text-end">
+    <%= f.submit "更新", class: "btn btn-primary" %>
+    <%= link_to "戻る", admin_theme_path(theme), class: "btn btn-secondary ms-2" %>
+  </div>
+<% end %>

--- a/app/views/admin/themes/edit.html.erb
+++ b/app/views/admin/themes/edit.html.erb
@@ -1,0 +1,9 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <div class="py-8">
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-gray-900">お題の編集</h1>
+    </div>
+
+    <%= render 'form', theme: @theme %>
+  </div>
+</div>

--- a/app/views/admin/themes/index.html.erb
+++ b/app/views/admin/themes/index.html.erb
@@ -1,0 +1,64 @@
+<div class="container">
+  <h1 class="text-center mb-4">お題の管理</h1>
+
+  <div class="mb-4">
+    <div class="btn-group">
+      <%= link_to '全て', admin_themes_path, class: "btn #{params[:filter].blank? ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <%= link_to '表示中', admin_themes_path(filter: 'available'), class: "btn #{params[:filter] == 'available' ? 'btn-primary' : 'btn-outline-primary'}" %>
+      <%= link_to '非表示', admin_themes_path(filter: 'deleted'), class: "btn #{params[:filter] == 'deleted' ? 'btn-primary' : 'btn-outline-primary'}" %>
+    </div>
+  </div>
+
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <div class="text-end mb-4">
+        <%= link_to '新規お題作成', new_admin_theme_path, class: "button button-primary" %>
+      </div>
+
+      <% @themes.each do |theme| %>
+        <div class="card mb-3">
+          <div class="card-body">
+            <% if theme.image.attached? %>
+              <%= image_tag theme.image, class: "w-100 rounded-lg mb-3" %>
+            <% end %>
+
+            <p class="text-muted"><%= theme.description %></p>
+
+            <div class="d-flex justify-content-between align-items-center mt-3">
+              <div>
+                <span class="badge <%= theme.status == 'published' ? 'bg-success' : 'bg-secondary' %>">
+                  <%= theme.status %>
+                </span>
+                <span class="badge bg-info ms-2">
+                  投稿数: <%= theme.posts.count %>
+                </span>
+                <% if theme.deleted_at.present? %>
+                  <span class="badge bg-danger me-1">非表示</span>
+                <% else %>
+                  <span class="badge bg-success me-1">表示中</span>
+                <% end %>
+              </div>
+              <div class="d-flex align-items-center">
+                <div class="text-muted me-3">
+                  <i class="far fa-heart"></i> <%= theme.likes.count %>
+                </div>
+                <div class="text-muted me-3">
+                  作成者: <%= theme.user.name %>
+                </div>
+                <small class="text-muted"><%= l theme.created_at, format: :long %></small>
+              </div>
+            </div>
+
+            <div class="mt-3">
+              <%= link_to '詳細', admin_theme_path(theme), class: 'btn btn-sm btn-outline-primary' %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <div class="d-flex justify-content-center mt-4">
+        <%= paginate @themes %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/themes/show.html.erb
+++ b/app/views/admin/themes/show.html.erb
@@ -1,0 +1,76 @@
+<div class="row justify-content-center">
+  <div class="col-md-8">
+    <div class="card mb-3">
+      <div class="card-body">
+        <% if @theme.image.attached? %>
+          <%= image_tag @theme.image, class: "w-100 rounded-lg" %>
+        <% end %>
+
+        <div class="mt-3">
+          <p class="text-muted"><%= @theme.description %></p>
+          <div class="d-flex justify-content-between align-items-center mt-2">
+            <div class="text-muted">
+              作成者: <%= @theme.user.name %>
+            </div>
+            <div class="text-muted">
+              <i class="far fa-heart"></i> <%= @theme.likes.count %>
+            </div>
+          </div>
+        </div>
+
+        <div class="d-flex justify-content-between align-items-center mt-3">
+          <div>
+            <span class="badge <%= @theme.status == 'published' ? 'bg-success' : 'bg-secondary' %>">
+              <%= @theme.status %>
+            </span>
+            <span class="badge bg-info ms-2">
+              投稿数: <%= @theme.posts.count %>
+            </span>
+          </div>
+          <small class="text-muted">作成日時: <%= l @theme.created_at, format: :long %></small>
+        </div>
+
+        <div class="mt-4">
+          <div class="btn-group">
+            <%= link_to '編集', edit_admin_theme_path(@theme), class: 'btn btn-primary' %>
+            <% if @theme.deleted_at.present? %>
+              <%= button_to '再表示', restore_admin_theme_path(@theme),
+                  method: :patch,
+                  class: 'btn btn-success' %>
+            <% else %>
+              <%= button_to '非表示', soft_delete_admin_theme_path(@theme),
+                  method: :patch,
+                  class: 'btn btn-warning' %>
+            <% end %>
+            <%= button_to '完全削除', admin_theme_path(@theme),
+                method: :delete,
+                class: 'btn btn-danger',
+                data: { turbo_confirm: 'このお題を完全に削除してもよろしいですか？\n（このお題で詠まれた句は削除されません）' } %>
+          </div>
+        </div>
+
+        <% if @theme.posts.any? %>
+          <div class="mt-4">
+            <h2 class="h4 mb-3">このお題で詠まれた句</h2>
+              <% @recent_posts.each do |post| %>
+                <div class="card mb-3">
+                  <div class="card-body">
+                    <div class="post-content mb-2">
+                      <%= simple_format(post.display_content) %>
+                    </div>
+                    <div class="text-muted mt-2">
+                      <%= post.user.name %> - <%= l post.created_at, format: :long %>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+          </div>
+        <% end %>
+
+        <div class="mt-4">
+          <%= render 'shared/back_button', fallback_path: admin_themes_path %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -36,9 +36,9 @@
 
       <% if @posts.exists? %>
         <div class="grid gap-4">
-          <% @posts.limit(3).each do |post| %>
-            <%= render partial: 'posts/post', locals: { post: post, show_like_button: false } %>
-          <% end %>
+          <%= render partial: 'posts/post',
+              collection: @posts.limit(3),
+              locals: { show_like_button: false } %>
         </div>
       <% else %>
         <p class="text-center text-muted">まだ句を投稿していません</p>
@@ -48,12 +48,16 @@
     <div class="mb-4">
       <div class="d-flex justify-content-between align-items-center mb-3">
         <h3 class="h5 mb-0">作成したお題一覧</h3>
-        <%= link_to "すべてのお題を見る (#{@user.themes.count})", themes_user_path(@user.id),
+        <%= link_to "すべてのお題を見る (#{@user.themes.available.count})", themes_user_path(@user.id),
             class: "text-decoration-none" %>
       </div>
 
-      <% if @user.themes.exists? %>
-        <%= render partial: 'themes/theme', collection: @user.themes.order(created_at: :desc).limit(3), locals: { show_like_button: false } %>
+      <% if @user.themes.available.exists? %>
+        <div class="grid gap-4">
+          <%= render partial: 'themes/theme',
+              collection: @user.themes.available.order(created_at: :desc).limit(3),
+              locals: { show_like_button: false } %>
+        </div>
       <% else %>
         <p class="text-center text-muted">まだお題を作成していません</p>
       <% end %>
@@ -68,9 +72,9 @@
 
       <% if @liked_posts.exists? %>
         <div class="grid gap-4">
-          <% @liked_posts.limit(3).each do |post| %>
-            <%= render partial: 'posts/post', locals: { post: post, show_like_button: false } %>
-          <% end %>
+          <%= render partial: 'posts/post',
+              collection: @liked_posts.limit(3),
+              locals: { show_like_button: false } %>
         </div>
       <% else %>
         <p class="text-center text-muted">まだいいねした句はありません</p>
@@ -85,7 +89,11 @@
       </div>
 
       <% if @liked_themes.exists? %>
-        <%= render partial: 'themes/theme', collection: @liked_themes.limit(3), locals: { show_like_button: false } %>
+        <div class="grid gap-4">
+          <%= render partial: 'themes/theme',
+              collection: @liked_themes.limit(3),
+              locals: { show_like_button: false } %>
+        </div>
       <% else %>
         <p class="text-center text-muted">まだいいねしたお題はありません</p>
       <% end %>

--- a/app/views/users/themes.html.erb
+++ b/app/views/users/themes.html.erb
@@ -1,4 +1,4 @@
-docker compose run web <div class="container mt-4">
+<div class="container mt-4">
   <div class="row justify-content-center">
     <div class="col-md-8">
       <h2 class="mb-4 h4"><%= @user.name %>さんが作成したお題一覧</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,20 @@ Rails.application.routes.draw do
         patch :activate
       end
     end
-    resources :posts, only: [:index, :edit, :update, :destroy]
+
+    resources :posts do
+      member do
+        patch :soft_delete
+        patch :restore
+      end
+    end
+
+    resources :themes do
+      member do
+        patch :soft_delete
+        patch :restore
+      end
+    end
   end
 
   root 'home#index'

--- a/db/migrate/20250201121017_add_status_to_themes.rb
+++ b/db/migrate/20250201121017_add_status_to_themes.rb
@@ -1,0 +1,6 @@
+class AddStatusToThemes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :themes, :status, :integer, default: 0
+    add_index :themes, :status
+  end
+end

--- a/db/migrate/20250201131931_add_deleted_at_to_posts.rb
+++ b/db/migrate/20250201131931_add_deleted_at_to_posts.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :posts, :deleted_at, :datetime
+  end
+end

--- a/db/migrate/20250201145540_add_deleted_at_to_themes.rb
+++ b/db/migrate/20250201145540_add_deleted_at_to_themes.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToThemes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :themes, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_31_082550) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_01_145540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -80,6 +80,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_31_082550) do
     t.bigint "image_post_id"
     t.bigint "theme_id"
     t.integer "likes_count", default: 0
+    t.datetime "deleted_at"
     t.index ["image_post_id"], name: "index_posts_on_image_post_id"
     t.index ["theme_id"], name: "index_posts_on_theme_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
@@ -100,7 +101,10 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_31_082550) do
     t.datetime "updated_at", null: false
     t.bigint "image_post_id"
     t.integer "likes_count", default: 0
+    t.integer "status", default: 0
+    t.datetime "deleted_at"
     t.index ["image_post_id"], name: "index_themes_on_image_post_id"
+    t.index ["status"], name: "index_themes_on_status"
     t.index ["user_id"], name: "index_themes_on_user_id"
   end
 


### PR DESCRIPTION
# 句とお題の管理画面の実装

## 概要
管理者が句とお題を管理できる機能を実装し、各コンテンツの表示・非表示の切り替え機能を追加しました。

## 実装内容
### 管理機能の追加
- 句の管理（一覧・詳細・編集・削除）  
- お題の管理（一覧・詳細・編集・削除）
- サイドバーへの管理メニュー追加

### 表示制御機能
- 句とお題の表示・非表示切り替え
- 管理画面での非表示コンテンツの確認
- 一般ユーザー画面での非表示コンテンツの制御

### UI/UX改善
- 管理画面の統一的なデザイン適用
- ステータス（表示中/非表示）のバッジ表示
- フォーム送信時の適切なフィードバック

## 動作確認項目

1. [x] 管理機能
- 句とお題の一覧表示が正しく機能する
- 詳細画面で適切な情報が表示される
- 編集・削除が正常に動作する

2. [x] 表示制御機能
- 表示・非表示の切り替えが正しく機能する
- 非表示コンテンツが一般画面で表示されない
- 管理画面でのみ非表示コンテンツが確認できる

3. [x] アクセス制御
- 管理者以外が管理機能にアクセスできない
- 適切なリダイレクトと通知が行われる

## 技術的変更点
- 論理削除機能の実装（deleted_atカラムの追加）
- 管理者用コントローラーとビューの作成
- モデルへのスコープとバリデーションの追加
- トランザクション処理の実装

## テスト実施内容
- 管理機能の各操作確認
- 表示・非表示切り替えの動作確認
- 一般ユーザー画面での表示制御確認
- 権限チェックの動作確認
- レスポンシブ動作の確認

## 影響範囲
- 句とお題の表示制御
- ユーザー画面での投稿表示
- 管理者の操作権限

## 補足事項
- 管理画面は管理者ユーザーのみアクセス可能
- 非表示コンテンツは管理画面でのみ確認・編集可能
- データの完全削除と論理削除を区別して実装