### PR TITLE
すべての句の一覧

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -52,6 +52,14 @@ class PostsController < ApplicationController
     flash.now[:alert] = "投稿の取得中にエラーが発生しました"
   end
 
+  def all_posts
+    @posts = Post.includes(:user, :tags, :theme, :image_post)
+                .where(deleted_at: nil)
+                .order(created_at: :desc)
+                .page(params[:page])
+                .per(20)
+  end
+
   def show
     @post = Post.includes(:user, :tags, :theme, :image_post).find(params[:id])
     @theme = if @post.theme.present?

--- a/app/views/posts/all_posts.html.erb
+++ b/app/views/posts/all_posts.html.erb
@@ -1,0 +1,25 @@
+<% content_for :with_direction_toggle, true %>
+
+<div class="container">
+  <h1 class="mb-4 text-center">すべての句</h1>
+
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <% if @posts.any? %>
+        <% @posts.each do |post| %>
+          <%= render partial: 'post', locals: { post: post, show_like_button: true } %>
+        <% end %>
+
+        <div class="d-flex justify-content-center mt-4">
+          <%= paginate @posts %>
+        </div>
+      <% else %>
+        <p class="text-center text-muted fs-5">
+          投稿された句はありません
+        </p>
+      <% end %>
+    </div>
+
+    <%= render 'shared/back_button', fallback_path: posts_path %>
+  </div>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,7 +4,7 @@
   <div class="text-center">
     <h1 class="mb-4"><%= @date.strftime('%Y年%-m月%-d日') %>の投稿</h1>
 
-    <div class="d-flex justify-content-center align-items-center mb-5 gap-2">
+    <div class="d-flex justify-content-center align-items-center mb-3 gap-2">
       <%= link_to posts_path(date: @prev_date), class: "btn btn-outline-primary" do %>
         <i class="bi bi-arrow-left"></i> 前の日
       <% end %>
@@ -16,6 +16,10 @@
       <%= link_to posts_path(date: @next_date), class: "btn btn-outline-primary" do %>
         次の日 <i class="bi bi-arrow-right"></i>
       <% end %>
+    </div>
+
+    <div class="d-flex justify-content-center mt-2 mb-5">
+      <%= link_to 'すべての句を見る', all_posts_path, class: 'btn btn-primary' %>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'posts/all', to: 'posts#all_posts', as: 'all_posts'
+
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'


### PR DESCRIPTION
# すべての句を見る機能の追加

## 概要
一日ごとの句の表示に加えて、すべての投稿を一覧で表示できる機能を追加しました。

## 実装内容
### 一覧表示機能の追加
- すべての句を表示するページの作成
- 削除された投稿を除外した表示
- 20件ごとのページネーション実装

### UI/UX改善
- 「すべての句を見る」ボタンの追加
- 既存の表示形式（_postパーシャル）の活用
- ボタン配置とマージンの最適化

## 動作確認項目

1. [x] 一覧表示機能
- すべての投稿が正しく表示される
- 削除された投稿が表示されない
- ページネーションが正常に機能する

2. [x] 既存機能との連携
- いいね機能が正常に動作する
- タグ表示が正しく機能する
- 投稿詳細へのリンクが機能する

3. [x] UI/UXの整合性
- 既存の表示形式が維持されている
- ボタンの配置が適切
- レスポンシブデザインが機能する

## 技術的変更点
- `all_posts`アクションの追加
- ページネーションの実装（kaminariの活用）
- 削除済み投稿の除外処理

## テスト実施内容
- 一覧表示の動作確認
- ページネーションの動作確認
- 削除された投稿の非表示確認
- 各機能（いいね、タグ等）の動作確認
- レスポンシブ動作の確認

## 影響範囲
- 投稿一覧の表示方法
- ナビゲーションの構造

## 補足事項
- 既存の`_post`パーシャルを活用し、表示の一貫性を維持
- 20件ごとのページネーションで快適なブラウジングを実現