### PR TITLE
並び替えの実装

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,4 +1,6 @@
 class Admin::BaseController < ApplicationController
+  include Sortable
+
   before_action :require_login
   before_action :check_admin
   layout 'admin/application'

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -13,7 +13,7 @@ class Admin::PostsController < Admin::BaseController
               @posts
             end
 
-    @posts = @posts.order(created_at: :desc).page(params[:page]).per(20)
+    @posts = sort_records(@posts).page(params[:page]).per(20)
   end
 
   def show

--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -13,9 +13,7 @@ class Admin::ThemesController < Admin::BaseController
                 @themes
               end
 
-    @themes = @themes.order(created_at: :desc)
-                    .page(params[:page])
-                    .per(20)
+    @themes = sort_records(@themes).page(params[:page]).per(20)
   end
 
   def show

--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -1,0 +1,38 @@
+module Sortable
+  extend ActiveSupport::Concern
+
+  private
+
+  def sort_records(records)
+    case params[:sort]
+    when 'oldest'
+      records.order(created_at: :asc)
+    when 'most_likes'
+      records.left_joins(:likes)
+              .group("#{records.table.name}.id")
+              .order('COUNT(likes.id) DESC, created_at DESC')
+    when 'least_likes'
+      records.left_joins(:likes)
+              .group("#{records.table.name}.id")
+              .order('COUNT(likes.id) ASC, created_at DESC')
+    when 'most_posts'
+      if records.model == Theme
+        records.left_joins(:posts)
+                .group('themes.id')
+                .order('COUNT(posts.id) DESC, themes.created_at DESC')
+      else
+        records.order(created_at: :desc)
+      end
+    when 'least_posts'
+      if records.model == Theme
+        records.left_joins(:posts)
+                .group('themes.id')
+                .order('COUNT(posts.id) ASC, themes.created_at DESC')
+      else
+        records.order(created_at: :desc)
+      end
+    else
+      records.order(created_at: :desc)
+    end
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  include Sortable
+
   before_action :require_login, except: [:show, :index]
   before_action :ensure_correct_user, only: [:destroy]
   before_action :load_post_from_session, only: [:new_reading, :new_content, :confirm]
@@ -18,9 +20,8 @@ class PostsController < ApplicationController
     @posts = Post.available
               .includes(:user, :tags, :image_post, theme: [:posts, :image_attachment])
               .where(created_at: @date.all_day)
-              .order(created_at: :desc)
-              .page(params[:page])
-              .per(10)
+
+    @posts = sort_records(@posts).page(params[:page]).per(20)
 
     @prev_date = @date - 1.day
     @next_date = @date + 1.day
@@ -55,9 +56,8 @@ class PostsController < ApplicationController
   def all_posts
     @posts = Post.includes(:user, :tags, :theme, :image_post)
                 .where(deleted_at: nil)
-                .order(created_at: :desc)
-                .page(params[:page])
-                .per(20)
+
+    @posts = sort_records(@posts).page(params[:page]).per(20)
   end
 
   def show

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -1,19 +1,16 @@
 class ThemesController < ApplicationController
+  include Sortable
+
   before_action :set_theme, only: [:show, :edit, :update, :destroy, :all_posts]
   skip_before_action :require_login, only: [:index, :show, :all_posts]
 
   def index
-    base_themes = Theme.available
-                      .includes(:user, :posts, :likes)
-                      .order(created_at: :desc)
+    @themes = Theme.available
+                  .includes(:user, :posts, :likes)
 
-    @themes = if params[:user_id].present?
-                base_themes.where(user_id: params[:user_id])
-              else
-                base_themes
-              end
+    @themes = @themes.where(user_id: params[:user_id]) if params[:user_id].present?
 
-    @themes = @themes.page(params[:page]).per(10)
+    @themes = sort_records(@themes).page(params[:page]).per(20)
   end
 
   def show
@@ -30,9 +27,7 @@ class ThemesController < ApplicationController
     ensure_theme_visible
     @show_like_button = false
     @posts = @theme.posts.includes(:user, :tags)
-                  .order(created_at: :desc)
-                  .page(params[:page])
-                  .per(10)
+    @posts = sort_records(@posts).page(params[:page]).per(20)
   end
 
   def new

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,7 +9,7 @@ class Post < ApplicationRecord
   attr_accessor :skip_tag_validation
   belongs_to :user
   belongs_to :image_post, optional: true
-  belongs_to :theme, optional: true
+  belongs_to :theme, counter_cache: true, optional: true
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
   has_many :likes, as: :likeable, dependent: :destroy

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -2,6 +2,10 @@
   <h1 class="text-center mb-4">句の管理</h1>
 
   <div class="mb-4">
+    <%= render 'shared/sort_options' %>
+  </div>
+
+  <div class="mb-4">
     <div class="btn-group">
       <%= link_to '全て', admin_posts_path, class: "btn #{params[:filter].blank? ? 'btn-primary' : 'btn-outline-primary'}" %>
       <%= link_to '表示中', admin_posts_path(filter: 'available'), class: "btn #{params[:filter] == 'available' ? 'btn-primary' : 'btn-outline-primary'}" %>

--- a/app/views/admin/themes/index.html.erb
+++ b/app/views/admin/themes/index.html.erb
@@ -2,6 +2,10 @@
   <h1 class="text-center mb-4">お題の管理</h1>
 
   <div class="mb-4">
+    <%= render 'shared/sort_options' %>
+  </div>
+
+  <div class="mb-4">
     <div class="btn-group">
       <%= link_to '全て', admin_themes_path, class: "btn #{params[:filter].blank? ? 'btn-primary' : 'btn-outline-primary'}" %>
       <%= link_to '表示中', admin_themes_path(filter: 'available'), class: "btn #{params[:filter] == 'available' ? 'btn-primary' : 'btn-outline-primary'}" %>

--- a/app/views/posts/all_posts.html.erb
+++ b/app/views/posts/all_posts.html.erb
@@ -3,6 +3,10 @@
 <div class="container">
   <h1 class="mb-4 text-center">すべての句</h1>
 
+  <div class="mb-4">
+    <%= render 'shared/sort_options' %>
+  </div>
+
   <div class="row justify-content-center">
     <div class="col-md-8">
       <% if @posts.any? %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -23,6 +23,10 @@
     </div>
   </div>
 
+  <div class="mb-4">
+    <%= render 'shared/sort_options' %>
+  </div>
+
   <%# 投稿一覧 %>
   <%= render 'daily_posts' %>
 </div>

--- a/app/views/shared/_sort_options.html.erb
+++ b/app/views/shared/_sort_options.html.erb
@@ -1,0 +1,34 @@
+<div class="sort-options d-flex mb-4">
+  <%= form_with(url: request.path, method: :get, local: true, class: "d-inline-flex") do |f| %>
+    <% if params[:filter].present? %>
+      <%= hidden_field_tag :filter, params[:filter] %>
+    <% end %>
+    <% options = if controller_name == 'themes'
+                  [
+                    ['新しい順', 'newest'],
+                    ['古い順', 'oldest'],
+                    ['いいねが多い順', 'most_likes'],
+                    ['いいねが少ない順', 'least_likes'],
+                    ['詠まれた句が多い順', 'most_posts'],
+                    ['詠まれた句が少ない順', 'least_posts']
+                  ]
+                else
+                  [
+                    ['新しい順', 'newest'],
+                    ['古い順', 'oldest'],
+                    ['いいねが多い順', 'most_likes'],
+                    ['いいねが少ない順', 'least_likes']
+                  ]
+                end
+    %>
+    <%= f.select :sort,
+      options_for_select(options, selected: params[:sort] || 'newest'),
+      {},
+      {
+        class: 'form-select form-select-sm',
+        style: 'width: auto;',
+        onchange: 'this.form.submit()'
+      }
+    %>
+  <% end %>
+</div>

--- a/app/views/themes/all_posts.html.erb
+++ b/app/views/themes/all_posts.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row justify-content-center">
   <div class="col-md-8">
-    <div class="card mb-3">
+    <div class="card mb-4">
       <div class="card-body">
         <% if @theme.image.attached? %>
           <div class="text-center mb-4">
@@ -10,52 +10,48 @@
             <p class="mt-2 mb-0"><%= @theme.description %></p>
           </div>
         <% end %>
+      </div>
+    </div>
 
-        <h2 class="text-center h4 mb-4">このお題で詠まれた句 （<%= @posts.total_count %>件）</h2>
+    <h2 class="text-center h4 mb-4">このお題で詠まれた句 （<%= @posts.total_count %>件）</h2>
+    <%= render 'shared/sort_options' %>
 
-        <% if @posts.any? %>
-          <div class="mt-4">
-            <% @posts.each do |post| %>
-              <div class="card mb-3">
-                <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
-                  <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-3">
-                      <div>
-                        <% post.tags.each do |tag| %>
-                          <% if ['俳句', '川柳'].include?(tag.name) %>
-                            <span class="badge bg-primary me-1"><%= tag.name %></span>
-                          <% else %>
-                            <span class="badge bg-secondary me-1"><%= tag.name %></span>
-                          <% end %>
-                        <% end %>
-                        <%= render 'shared/post_badges', post: post %>
-                      </div>
-                      <small class="text-muted"><%= l post.created_at, format: :long %></small>
-                    </div>
-                    <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
-                  </div>
+    <% @posts.each do |post| %>
+      <div class="card mb-4">
+        <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
+          <div class="card-body">
+            <div class="d-flex justify-content-between align-items-start mb-3">
+              <div>
+                <% post.tags.each do |tag| %>
+                  <% if ['俳句', '川柳'].include?(tag.name) %>
+                    <span class="badge bg-primary me-1"><%= tag.name %></span>
+                  <% else %>
+                    <span class="badge bg-secondary me-1"><%= tag.name %></span>
+                  <% end %>
                 <% end %>
-
-                <div class="card-footer bg-transparent">
-                  <div class="d-flex justify-content-end">
-                    <%= render 'shared/like_count', likeable: post %>
-                  </div>
-                </div>
+                <%= render 'shared/post_badges', post: post %>
               </div>
-            <% end %>
-
-            <div class="mt-4">
-              <%= paginate @posts %>
+              <small class="text-muted"><%= l post.created_at, format: :long %></small>
             </div>
+            <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
           </div>
-        <% else %>
-          <p class="text-center text-muted">まだ句が詠まれていません</p>
         <% end %>
-
-        <div class="text-center mt-4">
-          <%= render 'shared/back_button', fallback_path: theme_path(@theme) %>
+        <div class="card-footer bg-transparent">
+          <div class="d-flex justify-content-end">
+            <%= render 'shared/like_count', likeable: post %>
+          </div>
         </div>
       </div>
+    <% end %>
+
+    <% if @posts.any? %>
+      <div class="d-flex justify-content-center mb-4">
+        <%= paginate @posts %>
+      </div>
+    <% end %>
+
+    <div class="text-center">
+      <%= render 'shared/back_button', fallback_path: theme_path(@theme) %>
     </div>
   </div>
 </div>

--- a/app/views/themes/index.html.erb
+++ b/app/views/themes/index.html.erb
@@ -2,6 +2,10 @@
 
 <h1 class="text-center mb-4">お題一覧</h1>
 
+<div class="mb-4">
+  <%= render 'shared/sort_options' %>
+</div>
+
 <% if @themes.any? %>
   <div class="row justify-content-center">
     <div class="col-md-8">

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -2,7 +2,8 @@
 
 <div class="row justify-content-center">
   <div class="col-md-8">
-    <div class="card mb-3">
+
+    <div class="card mb-4">
       <div class="card-body">
         <% if @theme.image.attached? %>
           <%= image_tag @theme.image, class: "w-100 rounded-lg" %>
@@ -22,113 +23,104 @@
             </div>
           <% end %>
         </div>
-
-        <% if @first_post.present? %>
-          <div class="mt-4">
-            <h2 class="h4 mb-4"><%= @first_post.user == current_user ? "最初に自分が詠んだ句" : "最初に詠まれた句" %></h2>
-            <div class="card mb-3">
-              <%= link_to post_path(@first_post), class: "text-decoration-none", data: { turbo: false } do %>
-                <div class="card-body">
-                  <div class="d-flex justify-content-between align-items-start mb-2">
-                    <div class="tags">
-                      <% @first_post.tags.each do |tag| %>
-                        <% if ['俳句', '川柳'].include?(tag.name) %>
-                          <span class="badge bg-primary me-1"><%= tag.name %></span>
-                        <% else %>
-                          <span class="badge bg-secondary me-1"><%= tag.name %></span>
-                        <% end %>
-                      <% end %>
-                      <%= render 'shared/post_badges', post: @first_post %>
-                    </div>
-                    <small class="text-muted"><%= l @first_post.created_at, format: :long %></small>
-                  </div>
-                  <%= render partial: 'posts/post_content', locals: { content: @first_post.display_content } %>
-                </div>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-
-        <% if @my_post.present? && @my_post != @first_post %>
-          <div class="mt-4">
-            <h2 class="h4 mb-4">自分が詠んだ句</h2>
-            <div class="card mb-3">
-              <%= link_to post_path(@my_post), class: "text-decoration-none", data: { turbo: false } do %>
-                <div class="card-body">
-                  <div class="d-flex justify-content-between align-items-start mb-2">
-                    <div class="tags">
-                      <% @my_post.tags.each do |tag| %>
-                        <% if ['俳句', '川柳'].include?(tag.name) %>
-                          <span class="badge bg-primary me-1"><%= tag.name %></span>
-                        <% else %>
-                          <span class="badge bg-secondary me-1"><%= tag.name %></span>
-                        <% end %>
-                      <% end %>
-                      <%= render 'shared/post_badges', post: @my_post %>
-                    </div>
-                    <small class="text-muted"><%= l @my_post.created_at, format: :long %></small>
-                  </div>
-                  <%= render partial: 'posts/post_content', locals: { content: @my_post.display_content } %>
-                </div>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-
-        <% if @random_posts.any? %>
-          <div class="mt-4">
-            <h2 class="h4 mb-4">このお題で詠まれた句</h2>
-            <div class="grid gap-4">
-              <% @random_posts.each do |post| %>
-                <div class="card mb-3">
-                  <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
-                    <div class="card-body">
-                      <div class="d-flex justify-content-between align-items-start mb-2">
-                        <div class="tags">
-                          <% post.tags.each do |tag| %>
-                            <% if ['俳句', '川柳'].include?(tag.name) %>
-                              <span class="badge bg-primary me-1"><%= tag.name %></span>
-                            <% else %>
-                              <span class="badge bg-secondary me-1"><%= tag.name %></span>
-                            <% end %>
-                          <% end %>
-                          <%= render 'shared/post_badges', post: post %>
-                        </div>
-                        <small class="text-muted"><%= l post.created_at, format: :long %></small>
-                      </div>
-                      <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
-                    </div>
-                  <% end %>
-                </div>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-
-        <div class="text-center mt-4">
-          <%= link_to "このお題で詠まれたすべての句（#{@total_posts_count}件）",
-                    all_posts_theme_path(@theme),
-                    class: "text-decoration-none" %>
-        </div>
-
-        <% if logged_in? && !@theme.posted_by?(current_user) && current_user != @theme.user %>
-          <%= link_to 'このお題で詠む', new_type_theme_posts_path(@theme),
-              class: "button button-primary mt-4 d-block text-center" %>
-        <% end %>
-
-        <% if logged_in? && current_user == @theme.user %>
-          <div class="mt-4">
-            <%= button_to '削除', theme_path(@theme),
-                method: :delete,
-                data: { turbo_confirm: "このお題を削除してもよろしいですか？\n（このお題で詠まれた句は削除されません）" },
-                class: 'button button-danger' %>
-          </div>
-        <% end %>
-
-        <div class="mt-4">
-          <%= render 'shared/back_button', fallback_path: themes_path %>
-        </div>
       </div>
     </div>
+
+    <% if @first_post.present? %>
+
+    <h2 class="h4 mb-4"><%= @first_post.user == current_user ? "最初に自分が詠んだ句" : "最初に詠まれた句" %></h2>
+      <div class="card mb-4">
+        <div class="card-body">
+          <%= link_to post_path(@first_post), class: "text-decoration-none", data: { turbo: false } do %>
+            <div class="d-flex justify-content-between align-items-start mb-2">
+              <div class="tags">
+                <% @first_post.tags.each do |tag| %>
+                  <% if ['俳句', '川柳'].include?(tag.name) %>
+                    <span class="badge bg-primary me-1"><%= tag.name %></span>
+                  <% else %>
+                    <span class="badge bg-secondary me-1"><%= tag.name %></span>
+                  <% end %>
+                <% end %>
+                <%= render 'shared/post_badges', post: @first_post %>
+              </div>
+              <small class="text-muted"><%= l @first_post.created_at, format: :long %></small>
+            </div>
+            <%= render partial: 'posts/post_content', locals: { content: @first_post.display_content } %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <% if @my_post.present? && @my_post != @first_post %>
+      <div class="card mb-4">
+        <div class="card-body">
+          <h2 class="h4 mb-4">自分が詠んだ句</h2>
+          <%= link_to post_path(@my_post), class: "text-decoration-none", data: { turbo: false } do %>
+            <div class="d-flex justify-content-between align-items-start mb-2">
+              <div class="tags">
+                <% @my_post.tags.each do |tag| %>
+                  <% if ['俳句', '川柳'].include?(tag.name) %>
+                    <span class="badge bg-primary me-1"><%= tag.name %></span>
+                  <% else %>
+                    <span class="badge bg-secondary me-1"><%= tag.name %></span>
+                  <% end %>
+                <% end %>
+                <%= render 'shared/post_badges', post: @my_post %>
+              </div>
+              <small class="text-muted"><%= l @my_post.created_at, format: :long %></small>
+            </div>
+            <%= render partial: 'posts/post_content', locals: { content: @my_post.display_content } %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <% if @random_posts.any? %>
+
+    <h2 class="h4 mb-4">このお題で詠まれた句</h2>
+      <div class="grid gap-4">
+        <% @random_posts.each do |post| %>
+          <%= link_to post_path(post), class: "text-decoration-none", data: { turbo: false } do %>
+            <div class="card mb-3">
+              <div class="card-body">
+                <div class="d-flex justify-content-between align-items-start mb-2">
+                  <div class="tags">
+                    <% post.tags.each do |tag| %>
+                      <% if ['俳句', '川柳'].include?(tag.name) %>
+                        <span class="badge bg-primary me-1"><%= tag.name %></span>
+                      <% else %>
+                        <span class="badge bg-secondary me-1"><%= tag.name %></span>
+                      <% end %>
+                    <% end %>
+                    <%= render 'shared/post_badges', post: post %>
+                  </div>
+                  <small class="text-muted"><%= l post.created_at, format: :long %></small>
+                </div>
+                <%= render partial: 'posts/post_content', locals: { content: post.display_content } %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+
+  <div class="text-center">
+    <%= link_to "このお題で詠まれたすべての句（#{@total_posts_count}件）",
+        all_posts_theme_path(@theme),
+        class: "text-decoration-none mb-3 d-block" %>
+
+      <% if logged_in? && !@theme.posted_by?(current_user) && current_user != @theme.user %>
+        <%= link_to 'このお題で詠む', new_type_theme_posts_path(@theme),
+            class: "button button-primary mt-3 d-block" %>
+      <% end %>
+
+      <% if logged_in? && current_user == @theme.user %>
+        <%= button_to '削除', theme_path(@theme),
+            method: :delete,
+            data: { turbo_confirm: "このお題を削除してもよろしいですか？\n（このお題で詠まれた句は削除されません）" },
+            class: 'button button-danger mt-3' %>
+      <% end %>
+    </div>
+    <%= render 'shared/back_button', fallback_path: themes_path %>
   </div>
 </div>

--- a/app/views/users/liked_posts.html.erb
+++ b/app/views/users/liked_posts.html.erb
@@ -4,6 +4,10 @@
   <div class="col-md-8">
     <h2 class="mb-4 h4">いいねした句一覧</h2>
 
+    <div class="mb-4">
+      <%= render 'shared/sort_options' %>
+    </div>
+
     <% if @posts.present? %>
       <div class="grid gap-4">
         <%= render partial: 'posts/post', collection: @posts, locals: { show_like_button: @show_like_button } %>

--- a/app/views/users/liked_themes.html.erb
+++ b/app/views/users/liked_themes.html.erb
@@ -4,6 +4,10 @@
   <div class="col-md-8">
     <h2 class="mb-4 h4">いいねしたお題一覧</h2>
 
+    <div class="mb-4">
+      <%= render 'shared/sort_options' %>
+    </div>
+
     <% if @themes.present? %>
       <%= render @themes, show_like_button: @show_like_button %>
     <% else %>

--- a/app/views/users/posts.html.erb
+++ b/app/views/users/posts.html.erb
@@ -4,6 +4,10 @@
   <div class="col-md-8">
     <h2 class="mb-4 h4"><%= @user.name %>さんの投稿一覧</h2>
 
+    <div class="mb-4">
+      <%= render 'shared/sort_options' %>
+    </div>
+
     <% if @posts.any? %>
       <div class="grid gap-4">
         <% @posts.each do |post| %>

--- a/app/views/users/themes.html.erb
+++ b/app/views/users/themes.html.erb
@@ -3,6 +3,10 @@
     <div class="col-md-8">
       <h2 class="mb-4 h4"><%= @user.name %>さんが作成したお題一覧</h2>
 
+      <div class="mb-4">
+        <%= render 'shared/sort_options' %>
+      </div>
+
       <div class="grid gap-4">
         <% if @themes.any? %>
           <%= render partial: 'themes/theme', collection: @themes %>

--- a/db/migrate/20250204104350_add_indices_for_post_sorting.rb
+++ b/db/migrate/20250204104350_add_indices_for_post_sorting.rb
@@ -1,0 +1,6 @@
+class AddIndicesForPostSorting < ActiveRecord::Migration[7.0]
+  def change
+    add_index :posts, :created_at
+    add_index :likes, [:likeable_id, :likeable_type, :created_at], name: 'index_likes_on_likeable_and_created_at'
+  end
+end

--- a/db/migrate/20250204124851_add_indices_for_theme_sorting.rb
+++ b/db/migrate/20250204124851_add_indices_for_theme_sorting.rb
@@ -1,0 +1,7 @@
+class AddIndicesForThemeSorting < ActiveRecord::Migration[7.0]
+  def change
+    add_index :themes, :created_at
+    add_column :themes, :posts_count, :integer, default: 0
+    add_index :themes, :posts_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_01_145540) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_04_124851) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,6 +54,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_01_145540) do
     t.bigint "likeable_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["likeable_id", "likeable_type", "created_at"], name: "index_likes_on_likeable_and_created_at"
     t.index ["likeable_type", "likeable_id"], name: "index_likes_on_likeable"
     t.index ["likeable_type", "likeable_id"], name: "index_likes_on_likeable_type_and_likeable_id"
     t.index ["user_id", "likeable_type", "likeable_id"], name: "index_likes_on_user_id_and_likeable_type_and_likeable_id", unique: true
@@ -81,6 +82,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_01_145540) do
     t.bigint "theme_id"
     t.integer "likes_count", default: 0
     t.datetime "deleted_at"
+    t.index ["created_at"], name: "index_posts_on_created_at"
     t.index ["image_post_id"], name: "index_posts_on_image_post_id"
     t.index ["theme_id"], name: "index_posts_on_theme_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
@@ -103,7 +105,10 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_01_145540) do
     t.integer "likes_count", default: 0
     t.integer "status", default: 0
     t.datetime "deleted_at"
+    t.integer "posts_count", default: 0
+    t.index ["created_at"], name: "index_themes_on_created_at"
     t.index ["image_post_id"], name: "index_themes_on_image_post_id"
+    t.index ["posts_count"], name: "index_themes_on_posts_count"
     t.index ["status"], name: "index_themes_on_status"
     t.index ["user_id"], name: "index_themes_on_user_id"
   end


### PR DESCRIPTION
# 概要
句とお題の一覧に並び替え機能を追加しました。
また、お題の詳細画面とお題に紐づく句の一覧画面のレイアウトを改善しました。

## 実装内容
### 並び替え機能
句の一覧の並び替えオプション：
- 新しい順（デフォルト） 
- 古い順
- いいねが多い順
- いいねが少ない順

お題の一覧の並び替えオプション：
- 新しい順（デフォルト）
- 古い順 
- いいねが多い順
- いいねが少ない順
- 詠まれた句が多い順
- 詠まれた句が少ない順

管理画面の句・お題一覧にも同様の並び替え機能を追加しました。

### レイアウトの改善
お題の詳細画面の内容を複数のカードに分割し、視認性を向上させました：
- お題の情報
- 最初に詠まれた句 
- 自分が詠んだ句
- このお題で詠まれた句
- アクションボタン

お題に紐づく句の一覧画面も同様にカードを分割しました。

### 技術的変更点
- 並び替えの処理をSortableモジュールに集約
- 各コントローラーでモジュールをinclude
- 並び替えの処理速度向上のため、以下のインデックスを追加：
 - 作成日時のインデックス
 - いいね数のインデックス  
 - 投稿数のインデックス

## 動作確認項目
1. [ ] 句の一覧で各並び替えオプションが正しく機能すること
2. [ ] お題の一覧で各並び替えオプションが正しく機能すること
3. [ ] 管理画面でも並び替えが正しく機能すること
4. [ ] 並び替え状態でページネーションしても並び順が維持されること
5. [ ] お題詳細画面のレイアウトが崩れていないこと
6. [ ] お題に紐づく句一覧のレイアウトが崩れていないこと

## 影響範囲
- 句の一覧表示
- お題の一覧表示
- 管理画面の一覧表示
- お題の詳細画面のレイアウト

## 補足事項
- 並び替えのデフォルトは「新しい順」に設定
- 並び替えは非同期で行われ、ページ全体の再読み込みは発生しません
- 各カードのレイアウトは、今後の機能追加に対応できるよう拡張性を考慮