### PR TITLE
お問い合わせフォームの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,8 @@ gem "kaminari"
 
 gem 'enum_help'
 
+gem 'recaptcha'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,7 @@ GEM
     rake (13.2.1)
     rdoc (6.7.0)
       psych (>= 4.0.0)
+    recaptcha (5.19.0)
     regexp_parser (2.9.2)
     reline (0.5.11)
       io-console (~> 0.5)
@@ -318,6 +319,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)
+  recaptcha
   selenium-webdriver
   sorcery
   sprockets-rails

--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -1,0 +1,31 @@
+class Admin::ContactsController < Admin::BaseController
+  before_action :set_contact, only: [:show, :update]
+
+  def index
+    @contacts = Contact.recent
+                      .by_status(params[:status])
+                      .by_category(params[:category])
+                      .page(params[:page])
+  end
+
+  def show
+  end
+
+  def update
+    if @contact.update(contact_params)
+      redirect_to admin_contact_path(@contact), notice: '更新しました'
+    else
+      render :show
+    end
+  end
+
+  private
+
+  def set_contact
+    @contact = Contact.find(params[:id])
+  end
+
+  def contact_params
+    params.require(:contact).permit(:status, :admin_memo)
+  end
+end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,0 +1,44 @@
+class ContactsController < ApplicationController
+  skip_before_action :require_login
+
+  def confirm
+    @contact = Contact.new(contact_params)
+    if @contact.invalid?
+      render 'pages/contact'
+    else
+      render :confirm
+    end
+  end
+
+  def create
+    @contact = Contact.new(contact_params)
+    if params[:back]
+      render 'pages/contact'
+      return
+    end
+
+    if @contact.save
+      redirect_to thanks_contacts_path, notice: 'お問い合わせを受け付けました。'
+    else
+      render 'pages/contact'
+    end
+  end
+
+  def thanks
+  end
+
+  private
+
+  def contact_params
+    params.require(:contact).permit(
+      :name,
+      :email,
+      :content,
+      :category,
+      :privacy_policy_agreed
+    )
+  rescue ActionController::ParameterMissing
+    flash.now[:alert] = '不正なパラメータです'
+    {}
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,5 +11,16 @@ class PagesController < ApplicationController
   end
 
   def contact
+    if params[:contact]
+      @contact = Contact.new(contact_params)
+    else
+      @contact = Contact.new
+    end
+  end
+
+  private
+
+  def contact_params
+    params.require(:contact).permit(:name, :email, :content, :category, :privacy_policy_agreed)
   end
 end

--- a/app/helpers/admin/contacts_helper.rb
+++ b/app/helpers/admin/contacts_helper.rb
@@ -1,0 +1,12 @@
+module Admin::ContactsHelper
+  def status_badge_class(status)
+    case status
+    when 'pending'
+      'bg-warning text-dark'
+    when 'in_progress'
+      'bg-info text-dark'
+    when 'completed'
+      'bg-success'
+    end
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,0 +1,27 @@
+class Contact < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :email, presence: { message: 'を入力してください' }
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP, message: 'の形式が正しくありません' },
+                    length: { maximum: 255 },
+                    if: -> { email.present? }
+  validates :content, presence: true, length: { maximum: 2000 }
+  validates :category, presence: true
+  validates :privacy_policy_agreed, acceptance: true
+
+  enum status: {
+    pending: 'pending',
+    in_progress: 'in_progress',
+    completed: 'completed'
+  }, _default: 'pending'
+
+  enum category: {
+    general: 'general',
+    bug_report: 'bug_report',
+    feature_request: 'feature_request',
+    other: 'other'
+  }, _default: 'pending'
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :by_status, ->(status) { where(status: status) if status.present? }
+  scope :by_category, ->(category) { where(category: category) if category.present? }
+end

--- a/app/views/admin/contacts/index.html.erb
+++ b/app/views/admin/contacts/index.html.erb
@@ -1,0 +1,44 @@
+<div class="container-fluid py-4">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h2 class="mb-0">お問い合わせ一覧</h2>
+  </div>
+
+  <div class="card">
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>受付日時</th>
+              <th>お名前</th>
+              <th>種別</th>
+              <th>ステータス</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @contacts.each do |contact| %>
+              <tr>
+                <td><%= l contact.created_at %></td>
+                <td><%= contact.name %></td>
+                <td><%= t("enums.contact.category.#{contact.category}") %></td>
+                <td>
+                  <span class="badge <%= status_badge_class(contact.status) %>">
+                    <%= t("enums.contact.status.#{contact.status}") %>
+                  </span>
+                </td>
+                <td>
+                  <%= link_to "詳細", admin_contact_path(contact), class: "btn btn-sm btn-outline-primary" %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-4">
+    <%= paginate @contacts %>
+  </div>
+</div>

--- a/app/views/admin/contacts/show.html.erb
+++ b/app/views/admin/contacts/show.html.erb
@@ -1,0 +1,82 @@
+<div class="container py-4">
+  <div class="card">
+    <div class="card-header">
+      <h2 class="card-title h5 mb-0">お問い合わせ詳細</h2>
+    </div>
+
+    <div class="card-body">
+      <%= form_with(model: [:admin, @contact], local: true) do |f| %>
+        <div class="row mb-3">
+          <div class="col-sm-3">
+            <strong>受付日時</strong>
+          </div>
+          <div class="col-sm-9">
+            <%= l @contact.created_at, format: :long %>
+          </div>
+        </div>
+
+        <div class="row mb-3">
+          <div class="col-sm-3">
+            <strong>お名前</strong>
+          </div>
+          <div class="col-sm-9">
+            <%= @contact.name %>
+          </div>
+        </div>
+
+        <div class="row mb-3">
+          <div class="col-sm-3">
+            <strong>メールアドレス</strong>
+          </div>
+          <div class="col-sm-9">
+            <%= mail_to @contact.email %>
+          </div>
+        </div>
+
+        <div class="row mb-3">
+          <div class="col-sm-3">
+            <strong>種別</strong>
+          </div>
+          <div class="col-sm-9">
+            <%= t("enums.contact.category.#{@contact.category}") %>
+          </div>
+        </div>
+
+        <div class="row mb-3">
+          <div class="col-sm-3">
+            <strong>ステータス</strong>
+          </div>
+          <div class="col-sm-9">
+            <%= f.select :status,
+                Contact.statuses.keys.map { |k| [t("enums.contact.status.#{k}"), k] },
+                {},
+                class: "form-select" %>
+          </div>
+        </div>
+
+        <div class="row mb-3">
+          <div class="col-sm-3">
+            <strong>お問い合わせ内容</strong>
+          </div>
+          <div class="col-sm-9">
+            <%= simple_format(h(@contact.content)) %>
+          </div>
+        </div>
+
+        <div class="row mb-3">
+          <div class="col-sm-3">
+            <strong>対応メモ</strong>
+          </div>
+          <div class="col-sm-9">
+            <%= f.text_area :admin_memo, rows: 5, class: "form-control" %>
+          </div>
+        </div>
+
+        <div class="text-center">
+          <%= link_to "戻る", admin_contacts_path, class: "btn btn-secondary me-2" %>
+          <%= f.submit "更新する", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -19,5 +19,10 @@
         class: "list-group-item list-group-item-action #{controller_name == 'themes' ? 'active' : ''}" do %>
       お題の管理
     <% end %>
+
+    <%= link_to admin_contacts_path,
+        class: "list-group-item list-group-item-action #{controller_name == 'contacts' ? 'active' : ''}" do %>
+      お問い合わせ管理
+    <% end %>
   </div>
 </div>

--- a/app/views/contacts/confirm.html.erb
+++ b/app/views/contacts/confirm.html.erb
@@ -1,0 +1,68 @@
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <h2 class="text-center mb-4">お問い合わせ内容の確認</h2>
+
+      <%= form_with(model: @contact, local: true, data: { turbo: false }) do |f| %>
+        <div class="card mb-4">
+          <div class="card-body">
+            <div class="row mb-3">
+              <div class="col-sm-3">
+                <strong>お名前</strong>
+              </div>
+              <div class="col-sm-9">
+                <%= @contact.name %>
+                <%= f.hidden_field :name %>
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <div class="col-sm-3">
+                <strong>メールアドレス</strong>
+              </div>
+              <div class="col-sm-9">
+                <%= @contact.email %>
+                <%= f.hidden_field :email %>
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <div class="col-sm-3">
+                <strong>お問い合わせ種別</strong>
+              </div>
+              <div class="col-sm-9">
+                <%= t("enums.contact.category.#{@contact.category}") %>
+                <%= f.hidden_field :category %>
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <div class="col-sm-3">
+                <strong>お問い合わせ内容</strong>
+              </div>
+              <div class="col-sm-9">
+                <%= simple_format(h(@contact.content)) %>
+                <%= f.hidden_field :content %>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <%= f.hidden_field :privacy_policy_agreed %>
+
+        <div class="text-center">
+          <%= link_to "修正する", contact_path(
+            contact: {
+              name: @contact.name,
+              email: @contact.email,
+              category: @contact.category,
+              content: @contact.content,
+              privacy_policy_agreed: @contact.privacy_policy_agreed
+            }
+          ), class: "btn btn-secondary" %>
+          <%= f.submit "送信する", class: "btn btn-primary ms-2" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -1,0 +1,58 @@
+<div class="container py-5">
+  <h2 class="mb-4">お問い合わせ</h2>
+
+  <%= form_with(model: @contact, local: true) do |f| %>
+    <% if @contact.errors.any? %>
+      <div class="alert alert-danger">
+        <ul class="mb-0">
+          <% @contact.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="mb-3">
+      <%= f.label :name, "お名前", class: "form-label" %>
+      <span class="text-danger">*</span>
+      <%= f.text_field :name, class: "form-control" %>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :email, "メールアドレス", class: "form-label" %>
+      <span class="text-danger">*</span>
+      <%= f.email_field :email, class: "form-control" %>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :category, "お問い合わせ種別", class: "form-label" %>
+      <span class="text-danger">*</span>
+      <%= f.select :category,
+          Contact.categories.keys.map { |k| [t("enums.contact.category.#{k}"), k] },
+          { include_blank: "選択してください" },
+          { class: "form-select" } %>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :content, "お問い合わせ内容", class: "form-label" %>
+      <span class="text-danger">*</span>
+      <%= f.text_area :content, rows: 5, class: "form-control" %>
+    </div>
+
+    <div class="mb-3 form-check">
+      <%= f.check_box :privacy_policy_agreed, class: "form-check-input" %>
+      <%= f.label :privacy_policy_agreed, class: "form-check-label" do %>
+        プライバシーポリシーに同意する
+        <%= link_to "プライバシーポリシーを読む", privacy_policy_path, class: "link-primary", target: "_blank" %>
+      <% end %>
+    </div>
+
+    <div class="mb-3">
+      <%= recaptcha_tags %>
+    </div>
+
+    <div class="text-center">
+      <%= f.submit "確認する", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/contacts/thanks.html.erb
+++ b/app/views/contacts/thanks.html.erb
@@ -1,0 +1,9 @@
+<div class="container py-5 text-center">
+  <div class="mb-4">
+    <h2 class="mb-3">お問い合わせありがとうございます</h2>
+    <p class="mb-4">
+      お問い合わせを受け付けました。
+    </p>
+    <%= link_to "トップページに戻る", root_path, class: "btn btn-primary" %>
+  </div>
+</div>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -1,4 +1,55 @@
-<div class="max-w-4xl mx-auto px-4 py-8">
-  <h1 class="text-3xl font-bold mb-6">お問い合わせ</h1>
-  <!-- コンテンツを追加 -->
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <h2 class="text-center mb-4">お問い合わせ</h2>
+
+      <%= form_with(model: @contact, url: confirm_contacts_path, scope: :contact, local: true, data: { turbo: false }) do |f| %>
+        <% if @contact.errors.any? %>
+          <div class="alert alert-danger">
+            <ul class="mb-0">
+              <% @contact.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <div class="mb-3">
+          <%= f.label :name, "お名前", class: "form-label" %>
+          <span class="text-danger">*</span>
+          <%= f.text_field :name, class: "form-control" %>
+        </div>
+
+        <div class="mb-3">
+          <%= f.label :email, "メールアドレス", class: "form-label" %>
+          <span class="text-danger">*</span>
+          <%= f.email_field :email, class: "form-control" %>
+        </div>
+
+        <div class="mb-3">
+          <%= f.label :category, "お問い合わせ種別", class: "form-label" %>
+          <span class="text-danger">*</span>
+          <%= f.select :category,
+              Contact.categories.keys.map { |k| [t("enums.contact.category.#{k}"), k] },
+              { include_blank: "選択してください" },
+              { class: "form-select" } %>
+        </div>
+
+        <div class="mb-3">
+          <%= f.label :content, "お問い合わせ内容", class: "form-label" %>
+          <span class="text-danger">*</span>
+          <%= f.text_area :content, rows: 5, class: "form-control" %>
+        </div>
+
+        <div class="mb-3 form-check">
+          <%= f.check_box :privacy_policy_agreed, class: "form-check-input" %>
+          プライバシーポリシーに同意する
+        </div>
+
+        <div class="text-center">
+          <%= f.submit "確認する", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
       user: 'ユーザー'
       post: '句'
       tag: 'タグ'
+      contact: 'お問い合わせ'
     attributes:
       user:
         name: '名前'
@@ -18,6 +19,12 @@ ja:
         post_tags: 'タグ'
       tag:
         name: 'タグ名'
+      contact:
+        name: 'お名前'
+        email: 'メールアドレス'
+        content: 'お問い合わせ内容'
+        category: 'お問い合わせ種別'
+        privacy_policy_agreed: 'プライバシーポリシー'
     errors:
       models:
         user:
@@ -47,6 +54,19 @@ ja:
             base:
               tag_required: '俳句か川柳を選択してください'
               one_tag_only: '俳句か川柳のどちらか1つのみ選択できます'
+        contact:
+          attributes:
+            name:
+              blank: を入力してください
+            email:
+              blank: を入力してください
+              invalid: の形式が正しくありません
+            content:
+              blank: を入力してください
+            category:
+              blank: を選択してください
+            privacy_policy_agreed:
+              accepted: に同意してください
   time:
     formats:
       default: "%Y/%m/%d %H:%M"
@@ -91,6 +111,16 @@ ja:
       role:
         general: '一般ユーザー'
         admin: '管理者'
+    contact:
+      category:
+        general: '一般的なお問い合わせ'
+        bug_report: '不具合報告'
+        feature_request: '機能要望'
+        other: 'その他'
+      status:
+        pending: '未対応'
+        in_progress: '対応中'
+        completed: '対応済み'
 
   user_sessions:
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
         patch :restore
       end
     end
+
+    resources :contacts, only: [:index, :show, :update]
   end
 
   root 'home#index'
@@ -95,4 +97,11 @@ Rails.application.routes.draw do
   get 'terms', to: 'pages#terms', as: :terms
   get 'privacy', to: 'pages#privacy', as: :privacy
   get 'contact', to: 'pages#contact', as: :contact
+
+  resources :contacts, only: [:create] do
+    collection do
+      post :confirm
+      get :thanks
+    end
+  end
 end

--- a/db/migrate/20250205063142_create_contacts.rb
+++ b/db/migrate/20250205063142_create_contacts.rb
@@ -1,0 +1,20 @@
+class CreateContacts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :contacts do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.text :content, null: false
+      t.string :category, null: false
+      t.string :status, null: false, default: 'pending'
+      t.text :admin_memo
+      t.boolean :privacy_policy_agreed, null: false, default: false
+      t.datetime :responded_at
+
+      t.timestamps
+    end
+
+    add_index :contacts, :status
+    add_index :contacts, :category
+    add_index :contacts, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_04_124851) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_05_063142) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,22 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_04_124851) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "contacts", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.text "content", null: false
+    t.string "category", null: false
+    t.string "status", default: "pending", null: false
+    t.text "admin_memo"
+    t.boolean "privacy_policy_agreed", default: false, null: false
+    t.datetime "responded_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category"], name: "index_contacts_on_category"
+    t.index ["created_at"], name: "index_contacts_on_created_at"
+    t.index ["status"], name: "index_contacts_on_status"
   end
 
   create_table "image_posts", force: :cascade do |t|

--- a/test/fixtures/contacts.yml
+++ b/test/fixtures/contacts.yml
@@ -1,0 +1,21 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  email: MyString
+  content: MyText
+  category: MyString
+  status: MyString
+  admin_memo: MyText
+  privacy_policy_agreed: false
+  responded_at: 2025-02-05 06:31:42
+
+two:
+  name: MyString
+  email: MyString
+  content: MyText
+  category: MyString
+  status: MyString
+  admin_memo: MyText
+  privacy_policy_agreed: false
+  responded_at: 2025-02-05 06:31:42

--- a/test/models/contact_test.rb
+++ b/test/models/contact_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ContactTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# お問い合わせフォームの追加

## 概要
ユーザーがウェブサイト上で直接お問い合わせができるフォームを実装しました。管理者は管理画面でお問い合わせ内容を確認・管理できます。

## 実装内容
### お問い合わせフォームの実装
- 必須項目の設定（お名前、メールアドレス、お問い合わせ種別、お問い合わせ内容）
- プライバシーポリシーへの同意チェック
- 入力内容の確認画面
- 完了画面の表示
- エラーメッセージの日本語化

### 管理画面の実装
- お問い合わせ一覧の表示
- お問い合わせ詳細の表示
- ステータス管理（未対応、対応中、対応済み）
- 管理メモ機能

### お問い合わせ種別
- 一般的なお問い合わせ
- 不具合報告
- 機能要望
- その他

## 動作確認項目
1. [x] フォームの基本機能
  - 必須項目の入力チェック
  - メールアドレスの形式チェック
  - 確認画面の表示
  - 完了画面への遷移

2. [x] 管理画面の機能
  - 一覧表示
  - 詳細表示
  - ステータス変更
  - メモの追加・編集

3. [x] エラー表示
  - 適切なエラーメッセージの表示
  - フォームの再表示時のデータ保持

## 技術的変更点
- Contactモデルの作成
- お問い合わせ関連のコントローラー追加
- 管理画面のコントローラー追加
- バリデーションの実装
- 日本語化対応

## テスト実施内容
- フォームの入力検証
- バリデーションの動作確認
- 管理画面の機能確認
- レスポンシブ表示の確認

## 影響範囲
- ヘッダー・フッターのリンク
- 管理画面のナビゲーション
- ルーティング設定

## 補足事項
- 今後の機能拡張として以下を検討中：
 - reCAPTCHAの導入
 - メール通知機能の実装