### PR TITLE
投稿の削除申請

### DIFF
--- a/app/controllers/admin/deletion_requests_controller.rb
+++ b/app/controllers/admin/deletion_requests_controller.rb
@@ -1,0 +1,24 @@
+class Admin::DeletionRequestsController < Admin::BaseController
+  def index
+    @deletion_requests = DeletionRequest.includes(:user, :post).order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    @deletion_request = DeletionRequest.find(params[:id])
+  end
+
+  def approve
+    @deletion_request = DeletionRequest.find(params[:id])
+    @deletion_request.transaction do
+      @deletion_request.approved!
+      @deletion_request.post.soft_delete
+    end
+    redirect_to admin_deletion_requests_path, notice: '削除申請を承認しました'
+  end
+
+  def reject
+    @deletion_request = DeletionRequest.find(params[:id])
+    @deletion_request.rejected!
+    redirect_to admin_deletion_requests_path, notice: '削除申請を却下しました'
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
+  before_action :set_turbo_frame_request_variant
 
   private
 
@@ -18,5 +19,9 @@ class ApplicationController < ActionController::Base
 
   def flash_notice(message)
     flash[:notice] = message
+  end
+
+  def set_turbo_frame_request_variant
+    request.variant = :turbo_frame if turbo_frame_request?
   end
 end

--- a/app/controllers/deletion_requests_controller.rb
+++ b/app/controllers/deletion_requests_controller.rb
@@ -1,0 +1,62 @@
+class DeletionRequestsController < ApplicationController
+  before_action :require_login
+  before_action :set_post, only: [:new, :confirm, :create]
+  before_action :ensure_post_owner, only: [:new, :confirm, :create]
+
+  def new
+    @deletion_request = if params[:deletion_request].present?
+      DeletionRequest.new(deletion_request_params.merge(post: @post))
+    else
+      DeletionRequest.new(post: @post)
+    end
+  end
+
+  def confirm
+    @deletion_request = current_user.deletion_requests.build(deletion_request_params)
+    @deletion_request.post = @post
+
+    unless @deletion_request.valid?
+      return render :new
+    end
+
+    render :confirm
+  end
+
+  def create
+    @deletion_request = current_user.deletion_requests.build(deletion_request_params)
+    @deletion_request.post = @post
+
+    if params[:back].present?
+      render :new
+      return
+    end
+
+    if @deletion_request.save
+      redirect_to deletion_request_path(@deletion_request), notice: '削除申請を受け付けました'
+    else
+      render :new
+    end
+  end
+
+  def show
+    @deletion_request = current_user.deletion_requests.find(params[:id])
+  end
+
+  private
+
+  def deletion_request_params
+    params.require(:deletion_request).permit(:reason)
+  rescue ActionController::ParameterMissing
+    {}
+  end
+
+  def set_post
+    @post = Post.find(params[:post_id])
+  end
+
+  def ensure_post_owner
+    unless @post.user == current_user
+      redirect_to root_path, alert: '権限がありません'
+    end
+  end
+end

--- a/app/helpers/admin/deletion_requests_helper.rb
+++ b/app/helpers/admin/deletion_requests_helper.rb
@@ -1,0 +1,12 @@
+module Admin::DeletionRequestsHelper
+  def status_color_class(status)
+    case status
+    when 'pending'
+      'warning'
+    when 'approved'
+      'success'
+    when 'rejected'
+      'danger'
+    end
+  end
+end

--- a/app/helpers/deletion_requests_helper.rb
+++ b/app/helpers/deletion_requests_helper.rb
@@ -1,0 +1,2 @@
+module DeletionRequestsHelper
+end

--- a/app/models/deletion_request.rb
+++ b/app/models/deletion_request.rb
@@ -1,0 +1,17 @@
+class DeletionRequest < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  validates :reason, presence: true, length: { minimum: 10, maximum: 1000 }
+  enum status: { pending: 0, approved: 1, rejected: 2 }
+
+  validate :no_duplicate_requests, on: :create
+
+  private
+
+  def no_duplicate_requests
+    if DeletionRequest.exists?(post_id: post_id, status: :pending)
+      errors.add(:base, '既にこの投稿の削除申請が提出されています')
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,6 +14,7 @@ class Post < ApplicationRecord
   has_many :tags, through: :post_tags
   has_many :likes, as: :likeable, dependent: :destroy
   has_many :users_who_liked, through: :likes, source: :user
+  has_many :deletion_requests
 
   validates :reading, presence: { message: "読み方を入力してください" }
   validates :display_content, presence: { message: "本文が入力されていません" }
@@ -181,5 +182,9 @@ class Post < ApplicationRecord
     if image_post.present? && !theme.present? && !image_post.posts.exists?
       image_post.destroy
     end
+  end
+
+  def has_pending_deletion_request?
+    deletion_requests.where(status: 0).exists?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_many :visible_themes, -> { available }, class_name: 'Theme'
   has_many :liked_posts, through: :likes, source: :likeable, source_type: 'Post'
   has_many :liked_themes, through: :likes, source: :likeable, source_type: 'Theme'
+  has_many :deletion_requests
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/admin/deletion_requests/index.html.erb
+++ b/app/views/admin/deletion_requests/index.html.erb
@@ -1,0 +1,43 @@
+<div class="container-fluid">
+  <div class="d-flex justify-content-between mb-4">
+    <h1 class="h3">削除申請管理</h1>
+  </div>
+
+  <div class="card">
+    <div class="table-responsive">
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th>申請ID</th>
+            <th>申請者</th>
+            <th>削除理由</th>
+            <th>申請日時</th>
+            <th>ステータス</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @deletion_requests.each do |request| %>
+            <tr>
+              <td><%= request.id %></td>
+              <td><%= request.user.name %></td>
+              <td><%= truncate(request.reason, length: 30) %></td>
+              <td><%= l request.created_at, format: :long %></td>
+              <td>
+                <span class="badge bg-<%= request.pending? ? 'warning' : (request.approved? ? 'success' : 'danger') %>">
+                  <%= t("enums.deletion_request.status.#{request.status}") %>
+                </span>
+              </td>
+              <td>
+                <%= link_to '詳細', admin_deletion_request_path(request), class: 'btn btn-sm btn-info' %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    <div class="card-footer">
+      <%= paginate @deletion_requests %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/deletion_requests/show.html.erb
+++ b/app/views/admin/deletion_requests/show.html.erb
@@ -1,0 +1,71 @@
+<div class="container-fluid">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="h3 mb-0">削除申請詳細</h1>
+    <div>
+      <% if @deletion_request.pending? %>
+        <%= form_with(url: approve_admin_deletion_request_path(@deletion_request), method: :patch, class: 'd-inline', data: { turbo_confirm: '本当に承認しますか？' }) do |f| %>
+          <%= f.submit '承認する', class: 'btn btn-success' %>
+        <% end %>
+        <%= form_with(url: reject_admin_deletion_request_path(@deletion_request), method: :patch, class: 'd-inline ms-2', data: { turbo_confirm: '本当に却下しますか？' }) do |f| %>
+          <%= f.submit '却下する', class: 'btn btn-danger' %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <div class="card mb-4">
+        <div class="card-header">
+          <h5 class="card-title mb-0">基本情報</h5>
+        </div>
+        <div class="card-body">
+          <table class="table table-bordered">
+            <tr>
+              <th style="width: 200px">申請ID</th>
+              <td><%= @deletion_request.id %></td>
+            </tr>
+            <tr>
+              <th>申請者</th>
+              <td><%= @deletion_request.user.name %></td>
+            </tr>
+            <tr>
+              <th>申請日時</th>
+              <td><%= l @deletion_request.created_at, format: :long %></td>
+            </tr>
+            <tr>
+              <th>ステータス</th>
+              <td>
+                <span class="badge bg-<%= @deletion_request.pending? ? 'warning' : (@deletion_request.approved? ? 'success' : 'danger') %>">
+                  <%= t("enums.deletion_request.status.#{@deletion_request.status}") %>
+                </span>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header">
+          <h5 class="card-title mb-0">対象の投稿</h5>
+        </div>
+        <div class="card-body">
+          <%= @deletion_request.post.display_content %>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header">
+          <h5 class="card-title mb-0">削除理由</h5>
+        </div>
+        <div class="card-body">
+          <%= simple_format(h(@deletion_request.reason)) %>
+        </div>
+      </div>
+
+      <div class="card-footer text-end">
+        <%= link_to '削除申請一覧へ戻る', admin_deletion_requests_path, class: 'btn btn-secondary' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -24,5 +24,10 @@
         class: "list-group-item list-group-item-action #{controller_name == 'contacts' ? 'active' : ''}" do %>
       お問い合わせ管理
     <% end %>
+
+    <%= link_to admin_deletion_requests_path,
+        class: "list-group-item list-group-item-action #{controller_name == 'deletion_requests' ? 'active' : ''}" do %>
+      削除申請管理
+    <% end %>
   </div>
 </div>

--- a/app/views/deletion_requests/confirm.html.erb
+++ b/app/views/deletion_requests/confirm.html.erb
@@ -1,0 +1,5 @@
+<%= render 'shared/deletion_request_confirm',
+            record: @post,
+            deletion_request: @deletion_request,
+            content_type: '投稿',
+            create_path: post_deletion_requests_path(@post) %>

--- a/app/views/deletion_requests/new.html.erb
+++ b/app/views/deletion_requests/new.html.erb
@@ -1,0 +1,9 @@
+<%= render 'shared/deletion_request_form',
+            title: '投稿削除申請',
+            record: @post,
+            deletion_request: @deletion_request,
+            url: confirm_post_deletion_requests_path(@post),
+            method: :post,
+            content_type: '投稿',
+            submit_text: '確認する',
+            cancel_path: post_path(@post) %>

--- a/app/views/deletion_requests/show.html.erb
+++ b/app/views/deletion_requests/show.html.erb
@@ -1,0 +1,5 @@
+<%= render 'shared/deletion_request_detail',
+            deletion_request: @deletion_request,
+            record: @deletion_request.post,
+            content_type: '投稿',
+            return_path: posts_path %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -50,12 +50,13 @@
           <% end %>
         </div>
 
-        <% if logged_in? && current_user == @post.user %>
+        <% if current_user == @post.user %>
           <div class="mt-3">
-            <%= button_to '削除', post_path(@post),
-                method: :delete,
-                form: { data: { turbo_confirm: '本当に削除してもよろしいですか？' } },
-                class: 'button button-danger' %>
+            <% if @post.deletion_requests.where(status: :pending).exists? %>
+              <button class="btn btn-secondary" disabled>申請済み</button>
+            <% else %>
+              <%= link_to "削除申請", new_post_deletion_request_path(@post), class: "btn btn-warning" %>
+            <% end %>
           </div>
         <% end %>
       </div>

--- a/app/views/shared/_deletion_request_confirm.html.erb
+++ b/app/views/shared/_deletion_request_confirm.html.erb
@@ -1,0 +1,33 @@
+<div class="container py-5">
+  <h2 class="mb-4">削除申請の確認</h2>
+
+  <div class="card mb-4">
+    <div class="card-header">
+      対象の<%= content_type %>
+    </div>
+    <div class="card-body">
+      <%= record.display_content %>
+    </div>
+  </div>
+
+  <div class="card mb-4">
+    <div class="card-header">
+      削除理由
+    </div>
+    <div class="card-body">
+      <%= simple_format(h(deletion_request.reason)) %>
+    </div>
+  </div>
+
+  <%= form_with(model: [record, deletion_request],
+              url: create_path,
+              method: :post,
+              local: true,
+              data: { turbo: false }) do |f| %>
+    <%= f.hidden_field :reason %>
+    <div class="text-center">
+      <%= f.submit "申請する", class: "btn btn-primary" %>
+      <%= f.submit "修正する", name: "back", class: "btn btn-secondary ms-2" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_deletion_request_detail.html.erb
+++ b/app/views/shared/_deletion_request_detail.html.erb
@@ -1,0 +1,36 @@
+<div class="container py-5">
+  <h2 class="mb-4">削除申請の詳細</h2>
+
+  <div class="card mb-4">
+    <div class="card-header">
+      申請状況
+    </div>
+    <div class="card-body">
+      <span class="badge bg-<%= deletion_request.pending? ? 'warning' : (deletion_request.approved? ? 'success' : 'danger') %>">
+        <%= t("enums.deletion_request.status.#{deletion_request.status}") %>
+      </span>
+    </div>
+  </div>
+
+  <div class="card mb-4">
+    <div class="card-header">
+      対象の<%= content_type %>
+    </div>
+    <div class="card-body">
+      <%= record.display_content %>
+    </div>
+  </div>
+
+  <div class="card mb-4">
+    <div class="card-header">
+      削除理由
+    </div>
+    <div class="card-body">
+      <%= simple_format(h(deletion_request.reason)) %>
+    </div>
+  </div>
+
+  <div class="text-center">
+    <%= link_to "戻る", return_path, class: "btn btn-secondary" %>
+  </div>
+</div>

--- a/app/views/shared/_deletion_request_form.html.erb
+++ b/app/views/shared/_deletion_request_form.html.erb
@@ -1,0 +1,40 @@
+<div class="container py-5">
+  <h2 class="mb-4"><%= title %></h2>
+
+  <%= form_with(model: [record, deletion_request],
+              url: url,
+              method: method,
+              local: true,
+              data: { turbo: false }) do |f| %>
+    <% if deletion_request.errors.any? %>
+      <div class="alert alert-danger">
+        <ul class="mb-0">
+          <% deletion_request.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="card mb-4">
+      <div class="card-header">
+        対象の<%= content_type %>
+      </div>
+      <div class="card-body">
+        <%= record.display_content %>
+      </div>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :reason, "削除理由", class: "form-label" %>
+      <span class="text-danger">*</span>
+      <%= f.text_area :reason, rows: 5, class: "form-control" %>
+      <div class="form-text">削除を希望する理由を10文字以上1000文字以下で具体的に記入してください。</div>
+    </div>
+
+    <div class="text-center">
+      <%= f.submit submit_text, class: "btn btn-primary" %>
+      <%= link_to "キャンセル", cancel_path, class: "btn btn-secondary ms-2" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,7 @@ ja:
       post: '句'
       tag: 'タグ'
       contact: 'お問い合わせ'
+      deletion_request: '削除申請'
     attributes:
       user:
         name: '名前'
@@ -25,6 +26,8 @@ ja:
         content: 'お問い合わせ内容'
         category: 'お問い合わせ種別'
         privacy_policy_agreed: 'プライバシーポリシー'
+      deletion_request:
+        reason: '削除理由'
     errors:
       models:
         user:
@@ -67,6 +70,12 @@ ja:
               blank: を選択してください
             privacy_policy_agreed:
               accepted: に同意してください
+        deletion_request:
+          attributes:
+            reason:
+              blank: を入力してください
+              too_short: は%{count}文字以上で入力してください
+              too_long: は%{count}文字以下で入力してください
   time:
     formats:
       default: "%Y/%m/%d %H:%M"
@@ -121,6 +130,11 @@ ja:
         pending: '未対応'
         in_progress: '対応中'
         completed: '対応済み'
+    deletion_request:
+      status:
+        pending: '審査中'
+        approved: '承認済み'
+        rejected: '却下'
 
   user_sessions:
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,13 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :deletion_requests do
+      member do
+        patch :approve
+        patch :reject
+      end
+    end
+
     resources :contacts, only: [:index, :show, :update]
   end
 
@@ -104,4 +111,13 @@ Rails.application.routes.draw do
       get :thanks
     end
   end
+
+  resources :posts do
+    resources :deletion_requests, only: [:new, :create] do
+      collection do
+        post :confirm
+      end
+    end
+  end
+  resources :deletion_requests, only: [:show]
 end

--- a/db/migrate/20250206013748_create_deletion_requests.rb
+++ b/db/migrate/20250206013748_create_deletion_requests.rb
@@ -1,0 +1,12 @@
+class CreateDeletionRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :deletion_requests do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+      t.text :reason, null: false
+      t.integer :status, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250206023312_add_deleted_requests_to_posts.rb
+++ b/db/migrate/20250206023312_add_deleted_requests_to_posts.rb
@@ -1,0 +1,5 @@
+class AddDeletedRequestsToPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :deletion_requests, :post, foreign_key: true, null: false unless column_exists?(:deletion_requests, :post_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_05_063142) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_06_023312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,17 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_05_063142) do
     t.index ["category"], name: "index_contacts_on_category"
     t.index ["created_at"], name: "index_contacts_on_created_at"
     t.index ["status"], name: "index_contacts_on_status"
+  end
+
+  create_table "deletion_requests", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.text "reason", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_deletion_requests_on_post_id"
+    t.index ["user_id"], name: "index_deletion_requests_on_user_id"
   end
 
   create_table "image_posts", force: :cascade do |t|
@@ -145,6 +156,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_05_063142) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "deletion_requests", "posts"
+  add_foreign_key "deletion_requests", "users"
   add_foreign_key "likes", "users"
   add_foreign_key "post_tags", "posts"
   add_foreign_key "post_tags", "tags"

--- a/test/controllers/admin/deletion_requests_controller_test.rb
+++ b/test/controllers/admin/deletion_requests_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Admin::DeletionRequestsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get admin_deletion_requests_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get admin_deletion_requests_show_url
+    assert_response :success
+  end
+end

--- a/test/controllers/deletion_requests_controller_test.rb
+++ b/test/controllers/deletion_requests_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class DeletionRequestsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get deletion_requests_new_url
+    assert_response :success
+  end
+
+  test "should get confirm" do
+    get deletion_requests_confirm_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get deletion_requests_create_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get deletion_requests_show_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/deletion_requests.yml
+++ b/test/fixtures/deletion_requests.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  post: one
+  reason: MyText
+  status: 1
+
+two:
+  user: two
+  post: two
+  reason: MyText
+  status: 1

--- a/test/models/deletion_request_test.rb
+++ b/test/models/deletion_request_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DeletionRequestTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 投稿の削除申請機能の追加

## 概要
ユーザーが自身の投稿を削除する際に、管理者への申請形式に変更しました。管理者は申請内容を確認した上で、承認または却下の判断ができるようになります。

## 実装内容
### 削除申請機能の実装
- 削除理由の入力（10文字以上1000文字以下）
- 申請内容の確認画面
- 申請状況の確認画面
- 同一投稿への重複申請防止
- エラーメッセージの日本語化

### 管理画面の実装
- 削除申請一覧の表示
- 削除申請詳細の表示
- ステータス管理（審査中、承認済み、却下）
- 申請の承認・却下機能

### 申請ステータス
- 審査中：申請直後の初期状態
- 承認済み：管理者が承認し、投稿が削除された状態
- 却下：管理者が申請を却下した状態

## 動作確認項目
1. [x] 申請フォームの基本機能
  - 削除理由の文字数チェック（10文字以上1000文字以下）
  - 確認画面の表示と修正機能
  - 申請完了後の詳細画面表示

2. [x] 管理画面の機能
  - 申請一覧の表示
  - 申請詳細の表示
  - 承認・却下機能
  - 削除済み投稿の管理

3. [x] エラー表示
  - 適切なエラーメッセージの表示（日本語）
  - バリデーションエラー時のフォーム再表示
  - 重複申請の防止

## 技術的変更点
- DeletionRequestモデルの作成
- 削除申請関連のコントローラー追加
- 管理画面のコントローラー追加
- バリデーションの実装
- モデル間の関連付け（User, Post, DeletionRequest）
- 共通パーシャルの作成（フォーム、確認画面、詳細画面）

## テスト実施内容
- 申請フォームの入力検証
- バリデーションの動作確認
- 管理画面の機能確認
- 申請から承認/却下までの一連のフロー確認

## 影響範囲
- 投稿詳細画面の削除ボタン
- 管理画面のナビゲーション
- ユーザーの投稿削除フロー

## 補足事項
- パーシャル化により、今後お題の削除申請機能実装時に再利用可能
- 管理者による削除理由の記録機能は今後の課題として検討中