### PR TITLE
お題の削除申請

### DIFF
--- a/app/controllers/admin/theme_deletion_requests_controller.rb
+++ b/app/controllers/admin/theme_deletion_requests_controller.rb
@@ -1,0 +1,24 @@
+class Admin::ThemeDeletionRequestsController < Admin::BaseController
+  def index
+    @theme_deletion_requests = ThemeDeletionRequest.includes(:user, :theme).order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    @theme_deletion_request = ThemeDeletionRequest.find(params[:id])
+  end
+
+  def approve
+    @theme_deletion_request = ThemeDeletionRequest.find(params[:id])
+    @theme_deletion_request.transaction do
+      @theme_deletion_request.approved!
+      @theme_deletion_request.theme.soft_delete
+    end
+    redirect_to admin_theme_deletion_requests_path, notice: '削除申請を承認しました'
+  end
+
+  def reject
+    @theme_deletion_request = ThemeDeletionRequest.find(params[:id])
+    @theme_deletion_request.rejected!
+    redirect_to admin_theme_deletion_requests_path, notice: '削除申請を却下しました'
+  end
+end

--- a/app/controllers/theme_deletion_requests_controller.rb
+++ b/app/controllers/theme_deletion_requests_controller.rb
@@ -1,0 +1,62 @@
+class ThemeDeletionRequestsController < ApplicationController
+  before_action :require_login
+  before_action :set_theme, only: [:new, :confirm, :create]
+  before_action :ensure_theme_owner, only: [:new, :confirm, :create]
+
+  def new
+    @theme_deletion_request = if params[:theme_deletion_request].present?
+      ThemeDeletionRequest.new(theme_deletion_request_params.merge(theme: @theme))
+    else
+      ThemeDeletionRequest.new(theme: @theme)
+    end
+  end
+
+  def confirm
+    @theme_deletion_request = current_user.theme_deletion_requests.build(theme_deletion_request_params)
+    @theme_deletion_request.theme = @theme
+
+    unless @theme_deletion_request.valid?
+      return render :new
+    end
+
+    render :confirm
+  end
+
+  def create
+    @theme_deletion_request = current_user.theme_deletion_requests.build(theme_deletion_request_params)
+    @theme_deletion_request.theme = @theme
+
+    if params[:back].present?
+      render :new
+      return
+    end
+
+    if @theme_deletion_request.save
+      redirect_to theme_deletion_request_path(@theme_deletion_request), notice: '削除申請を受け付けました'
+    else
+      render :new
+    end
+  end
+
+  def show
+    @theme_deletion_request = current_user.theme_deletion_requests.find(params[:id])
+  end
+
+  private
+
+  def theme_deletion_request_params
+    params.require(:theme_deletion_request).permit(:reason)
+  rescue ActionController::ParameterMissing
+    {}
+  end
+
+  def set_theme
+    @theme = Theme.find(params[:theme_id])
+  end
+
+  def ensure_theme_owner
+    unless @theme.user == current_user
+      redirect_to root_path, alert: '権限がありません'
+    end
+  end
+end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -5,6 +5,7 @@ class Theme < ApplicationRecord
   has_one_attached :image
   has_many :likes, as: :likeable, dependent: :destroy
   has_many :users_who_liked, through: :likes, source: :user
+  has_many :theme_deletion_requests, dependent: :destroy
 
   validates :description, presence: { message: "お題を入力してください" }
   validates :status, presence: { message: "ステータスを選択してください" }
@@ -42,10 +43,6 @@ class Theme < ApplicationRecord
     image.variant(resize_to_limit: [200, 150])
   end
 
-  def status
-    'published'
-  end
-
   def soft_delete
     update!(deleted_at: Time.current)
   rescue => e
@@ -58,6 +55,10 @@ class Theme < ApplicationRecord
   rescue => e
     Rails.logger.error "Restore failed: #{e.message}"
     false
+  end
+
+  def display_content
+    description
   end
 
   private

--- a/app/models/theme_deletion_request.rb
+++ b/app/models/theme_deletion_request.rb
@@ -1,0 +1,36 @@
+class ThemeDeletionRequest < ApplicationRecord
+  belongs_to :user
+  belongs_to :theme
+
+  validates :reason, presence: true, length: { minimum: 10, maximum: 1000 }
+  enum status: { pending: 0, approved: 1, rejected: 2 }
+
+  validate :no_duplicate_requests, on: :create
+
+  def execute_deletion!
+    return false unless pending?
+
+    ActiveRecord::Base.transaction do
+      theme.posts.update_all(theme_id: nil)
+
+      if theme.soft_delete
+        update!(status: :approved)
+        true
+      else
+        raise ActiveRecord::Rollback
+        false
+      end
+    end
+  rescue => e
+    Rails.logger.error "Theme deletion failed: #{e.message}"
+    false
+  end
+
+  private
+
+  def no_duplicate_requests
+    if ThemeDeletionRequest.exists?(theme_id: theme_id, status: :pending)
+      errors.add(:base, '既にこのお題の削除申請が提出されています')
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :liked_posts, through: :likes, source: :likeable, source_type: 'Post'
   has_many :liked_themes, through: :likes, source: :likeable, source_type: 'Theme'
   has_many :posts_deletion_requests
+  has_many :theme_deletion_requests
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -29,5 +29,10 @@
         class: "list-group-item list-group-item-action #{controller_name == 'posts_deletion_requests' ? 'active' : ''}" do %>
       句の削除申請管理
     <% end %>
+
+    <%= link_to admin_theme_deletion_requests_path,
+        class: "list-group-item list-group-item-action #{controller_name == 'theme_deletion_requests' ? 'active' : ''}" do %>
+      お題の削除申請管理
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/theme_deletion_requests/index.html.erb
+++ b/app/views/admin/theme_deletion_requests/index.html.erb
@@ -1,0 +1,43 @@
+<div class="container-fluid">
+  <div class="d-flex justify-content-between mb-4">
+    <h1 class="h3">お題削除申請管理</h1>
+  </div>
+
+  <div class="card">
+    <div class="table-responsive">
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th>申請ID</th>
+            <th>申請者</th>
+            <th>削除理由</th>
+            <th>申請日時</th>
+            <th>ステータス</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @theme_deletion_requests.each do |request| %>
+            <tr>
+              <td><%= request.id %></td>
+              <td><%= request.user.name %></td>
+              <td><%= truncate(request.reason, length: 30) %></td>
+              <td><%= l request.created_at, format: :long %></td>
+              <td>
+                <span class="badge bg-<%= request.pending? ? 'warning' : (request.approved? ? 'success' : 'danger') %>">
+                  <%= t("enums.theme_deletion_request.status.#{request.status}") %>
+                </span>
+              </td>
+              <td>
+                <%= link_to '詳細', admin_theme_deletion_request_path(request), class: 'btn btn-sm btn-info' %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    <div class="card-footer">
+      <%= paginate @theme_deletion_requests %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/theme_deletion_requests/show.html.erb
+++ b/app/views/admin/theme_deletion_requests/show.html.erb
@@ -1,0 +1,71 @@
+<div class="container-fluid">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="h3 mb-0">お題削除申請詳細</h1>
+    <div>
+      <% if @theme_deletion_request.pending? %>
+        <%= form_with(url: approve_admin_theme_deletion_request_path(@theme_deletion_request), method: :patch, class: 'd-inline', data: { turbo_confirm: '本当に承認しますか？' }) do |f| %>
+          <%= f.submit '承認する', class: 'btn btn-success' %>
+        <% end %>
+        <%= form_with(url: reject_admin_theme_deletion_request_path(@theme_deletion_request), method: :patch, class: 'd-inline ms-2', data: { turbo_confirm: '本当に却下しますか？' }) do |f| %>
+          <%= f.submit '却下する', class: 'btn btn-danger' %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <div class="card mb-4">
+        <div class="card-header">
+          <h5 class="card-title mb-0">基本情報</h5>
+        </div>
+        <div class="card-body">
+          <table class="table table-bordered">
+            <tr>
+              <th style="width: 200px">申請ID</th>
+              <td><%= @theme_deletion_request.id %></td>
+            </tr>
+            <tr>
+              <th>申請者</th>
+              <td><%= @theme_deletion_request.user.name %></td>
+            </tr>
+            <tr>
+              <th>申請日時</th>
+              <td><%= l @theme_deletion_request.created_at, format: :long %></td>
+            </tr>
+            <tr>
+              <th>ステータス</th>
+              <td>
+                <span class="badge bg-<%= @theme_deletion_request.pending? ? 'warning' : (@theme_deletion_request.approved? ? 'success' : 'danger') %>">
+                  <%= t("enums.theme_deletion_request.status.#{@theme_deletion_request.status}") %>
+                </span>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header">
+          <h5 class="card-title mb-0">対象のお題</h5>
+        </div>
+        <div class="card-body">
+          <%= @theme_deletion_request.theme.description %>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header">
+          <h5 class="card-title mb-0">削除理由</h5>
+        </div>
+        <div class="card-body">
+          <%= simple_format(h(@theme_deletion_request.reason)) %>
+        </div>
+      </div>
+
+      <div class="card-footer text-end">
+        <%= link_to '削除申請一覧へ戻る', admin_theme_deletion_requests_path, class: 'btn btn-secondary' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_deletion_request_detail.html.erb
+++ b/app/views/shared/_deletion_request_detail.html.erb
@@ -3,17 +3,6 @@
 
   <div class="card mb-4">
     <div class="card-header">
-      申請状況
-    </div>
-    <div class="card-body">
-      <span class="badge bg-<%= deletion_request.pending? ? 'warning' : (deletion_request.approved? ? 'success' : 'danger') %>">
-        <%= t("enums.deletion_request.status.#{deletion_request.status}") %>
-      </span>
-    </div>
-  </div>
-
-  <div class="card mb-4">
-    <div class="card-header">
       対象の<%= content_type %>
     </div>
     <div class="card-body">

--- a/app/views/theme_deletion_requests/confirm.html.erb
+++ b/app/views/theme_deletion_requests/confirm.html.erb
@@ -1,0 +1,5 @@
+<%= render 'shared/deletion_request_confirm',
+            record: @theme,
+            deletion_request: @theme_deletion_request,
+            content_type: 'お題',
+            create_path: theme_theme_deletion_requests_path(@theme) %>

--- a/app/views/theme_deletion_requests/new.html.erb
+++ b/app/views/theme_deletion_requests/new.html.erb
@@ -1,0 +1,9 @@
+<%= render 'shared/deletion_request_form',
+            title: 'お題削除申請',
+            record: @theme,
+            deletion_request: @theme_deletion_request,
+            url: confirm_theme_theme_deletion_requests_path(@theme),
+            method: :post,
+            content_type: 'お題',
+            submit_text: '確認する',
+            cancel_path: theme_path(@theme) %>

--- a/app/views/theme_deletion_requests/show.html.erb
+++ b/app/views/theme_deletion_requests/show.html.erb
@@ -1,0 +1,5 @@
+<%= render 'shared/deletion_request_detail',
+            deletion_request: @theme_deletion_request,
+            record: @theme_deletion_request.theme,
+            content_type: 'お題',
+            return_path: themes_path %>

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -23,6 +23,16 @@
             </div>
           <% end %>
         </div>
+
+        <% if current_user == @theme.user %>
+          <div class="mt-3">
+            <% if @theme.theme_deletion_requests.where(status: :pending).exists? %>
+              <button class="btn btn-secondary" disabled>申請済み</button>
+            <% else %>
+              <%= link_to "削除申請", new_theme_theme_deletion_request_path(@theme), class: "btn btn-warning" %>
+            <% end %>
+          </div>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -123,13 +123,6 @@
         <%= link_to 'このお題で詠む', new_type_theme_posts_path(@theme),
             class: "button button-primary mt-3 d-block" %>
       <% end %>
-
-      <% if logged_in? && current_user == @theme.user %>
-        <%= button_to '削除', theme_path(@theme),
-            method: :delete,
-            data: { turbo_confirm: "このお題を削除してもよろしいですか？\n（このお題で詠まれた句は削除されません）" },
-            class: 'button button-danger mt-3' %>
-      <% end %>
     </div>
     <%= render 'shared/back_button', fallback_path: themes_path %>
   </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -135,6 +135,11 @@ ja:
         pending: '審査中'
         approved: '承認済み'
         rejected: '却下'
+    theme_deletion_request:
+      status:
+        pending: '審査中'
+        approved: '承認済み'
+        rejected: '却下'
 
   user_sessions:
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,13 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :theme_deletion_requests do
+      member do
+        patch :approve
+        patch :reject
+      end
+    end
+
     resources :contacts, only: [:index, :show, :update]
   end
 
@@ -120,4 +127,13 @@ Rails.application.routes.draw do
     end
   end
   resources :posts_deletion_requests, only: [:show]
+
+  resources :themes do
+    resources :theme_deletion_requests, only: [:new, :create] do
+      collection do
+        post :confirm
+      end
+    end
+  end
+  resources :theme_deletion_requests, only: [:show]
 end

--- a/db/migrate/20250207014612_create_theme_deletion_requests.rb
+++ b/db/migrate/20250207014612_create_theme_deletion_requests.rb
@@ -1,0 +1,12 @@
+class CreateThemeDeletionRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :theme_deletion_requests do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :theme, null: false, foreign_key: true
+      t.text :reason, null: false
+      t.integer :status, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_06_081023) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_07_014612) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -124,6 +124,17 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_06_081023) do
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
+  create_table "theme_deletion_requests", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "theme_id", null: false
+    t.text "reason", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["theme_id"], name: "index_theme_deletion_requests_on_theme_id"
+    t.index ["user_id"], name: "index_theme_deletion_requests_on_user_id"
+  end
+
   create_table "themes", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -167,6 +178,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_06_081023) do
   add_foreign_key "posts_deletion_requests", "posts"
   add_foreign_key "posts_deletion_requests", "themes"
   add_foreign_key "posts_deletion_requests", "users"
+  add_foreign_key "theme_deletion_requests", "themes"
+  add_foreign_key "theme_deletion_requests", "users"
   add_foreign_key "themes", "image_posts"
   add_foreign_key "themes", "users"
 end


### PR DESCRIPTION
# お題の削除申請機能の追加

## 概要
お題の削除機能を、投稿の削除申請と同様に管理者への申請形式に変更しました。管理者は申請内容を確認した上で、承認または却下の判断ができるようになります。

## 実装内容
### 削除申請機能の実装
- 削除理由の入力（10文字以上1000文字以下）
- 申請内容の確認画面
- 申請状況の確認画面
- 同一お題への重複申請防止
- エラーメッセージの日本語化

### 管理画面の実装
- 削除申請一覧の表示
- 削除申請詳細の表示
- ステータス管理（審査中、承認済み、却下）
- 申請の承認・却下機能

### 申請ステータス
- 審査中：申請直後の初期状態
- 承認済み：管理者が承認し、お題が削除された状態
- 却下：管理者が申請を却下した状態

## 動作確認項目
1. [x] 申請フォームの基本機能
  - 削除理由の文字数チェック（10文字以上1000文字以下）
  - 確認画面の表示と修正機能
  - 申請完了後の詳細画面表示

2. [x] 管理画面の機能
  - 申請一覧の表示
  - 申請詳細の表示
  - 承認・却下機能
  - 削除済みお題の管理

3. [x] エラー表示
  - 適切なエラーメッセージの表示（日本語）
  - バリデーションエラー時のフォーム再表示
  - 重複申請の防止

## 技術的変更点
- ThemeDeletionRequestモデルの作成
- お題削除申請関連のコントローラー追加
- 管理画面のコントローラー追加
- バリデーションの実装
- モデル間の関連付け（User, Theme, ThemeDeletionRequest）
- 削除申請用パーシャルの再利用

## テスト実施内容
- 申請フォームの入力検証
- バリデーションの動作確認
- 管理画面の機能確認
- 申請から承認/却下までの一連のフロー確認
- お題に紐づく投稿とイメージの関連を考慮した削除処理の確認

## 影響範囲
- お題詳細画面の削除ボタン
- 管理画面のナビゲーション
- ユーザーのお題削除フロー
- ThemeモデルとImagePostモデルの関連

## 補足事項
- 投稿の削除申請機能と同様の構造で実装
- 既存のパーシャルを再利用し、コードの重複を回避
- お題削除時の関連データ（投稿、イメージ）の整合性を保持