### PR TITLE
投稿の報告機能

### DIFF
--- a/app/controllers/admin/posts_reports_controller.rb
+++ b/app/controllers/admin/posts_reports_controller.rb
@@ -1,0 +1,24 @@
+class Admin::PostsReportsController < Admin::BaseController
+  def index
+    @posts_reports = PostsReport.includes(:user, :post).order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    @posts_report = PostsReport.find(params[:id])
+  end
+
+  def approve
+    @posts_report = PostsReport.find(params[:id])
+    @posts_report.transaction do
+      @posts_report.approved!
+      @posts_report.post.soft_delete
+    end
+    redirect_to admin_posts_reports_path, notice: '報告を承認しました'
+  end
+
+  def reject
+    @posts_report = PostsReport.find(params[:id])
+    @posts_report.rejected!
+    redirect_to admin_posts_reports_path, notice: '報告を却下しました'
+  end
+end

--- a/app/controllers/posts_reports_controller.rb
+++ b/app/controllers/posts_reports_controller.rb
@@ -1,0 +1,62 @@
+class PostsReportsController < ApplicationController
+  before_action :require_login
+  before_action :set_post, only: [:new, :confirm, :create]
+  before_action :ensure_not_post_owner, only: [:new, :confirm, :create]
+
+  def new
+    @posts_report = if params[:posts_report].present?
+      PostsReport.new(posts_report_params.merge(post: @post))
+    else
+      PostsReport.new(post: @post)
+    end
+  end
+
+  def confirm
+    @posts_report = current_user.posts_reports.build(posts_report_params)
+    @posts_report.post = @post
+
+    unless @posts_report.valid?
+      return render :new
+    end
+
+    render :confirm
+  end
+
+  def create
+    @posts_report = current_user.posts_reports.build(posts_report_params)
+    @posts_report.post = @post
+
+    if params[:back].present?
+      render :new
+      return
+    end
+
+    if @posts_report.save
+      redirect_to posts_report_path(@posts_report), notice: '報告を受け付けました'
+    else
+      render :new
+    end
+  end
+
+  def show
+    @posts_report = current_user.posts_reports.find(params[:id])
+  end
+
+  private
+
+  def posts_report_params
+    params.require(:posts_report).permit(:reason_category, :reason)
+  rescue ActionController::ParameterMissing
+    {}
+  end
+
+  def set_post
+    @post = Post.find(params[:post_id])
+  end
+
+  def ensure_not_post_owner
+    if @post.user == current_user
+      redirect_to root_path, alert: '自分の投稿は報告できません'
+    end
+  end
+end

--- a/app/helpers/posts_reports_helper.rb
+++ b/app/helpers/posts_reports_helper.rb
@@ -1,0 +1,7 @@
+module PostsReportsHelper
+  def reason_category_name(report)
+    return '' if report.nil? || report.reason_category.nil?
+
+    t("posts_reports.reason_categories.#{report.reason_category}")
+  end
+end

--- a/app/models/concerns/reportable.rb
+++ b/app/models/concerns/reportable.rb
@@ -1,0 +1,20 @@
+module Reportable
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :user
+
+    enum reason_category: {
+      inappropriate: 0,
+      spam: 1,
+      copyright: 2,
+      harassment: 3,
+      other: 4
+    }, _prefix: true
+
+    validates :reason, presence: true, length: { minimum: 10, maximum: 1000 }
+    validates :reason_category, presence: true
+
+    enum status: { pending: 0, approved: 1, rejected: 2 }
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,6 +15,7 @@ class Post < ApplicationRecord
   has_many :likes, as: :likeable, dependent: :destroy
   has_many :users_who_liked, through: :likes, source: :user
   has_many :posts_deletion_requests
+  has_many :posts_reports
 
   validates :reading, presence: { message: "読み方を入力してください" }
   validates :display_content, presence: { message: "本文が入力されていません" }
@@ -101,6 +102,10 @@ class Post < ApplicationRecord
     end
 
     count
+  end
+
+  def reported_by?(user)
+    posts_reports.where(user: user, status: :pending).exists?
   end
 
   private

--- a/app/models/posts_report.rb
+++ b/app/models/posts_report.rb
@@ -1,0 +1,22 @@
+class PostsReport < ApplicationRecord
+  include Reportable
+  belongs_to :user
+  belongs_to :post
+
+  validate :cannot_report_own_post, on: :create
+  validate :no_duplicate_reports, on: :create
+
+  private
+
+  def cannot_report_own_post
+    if user_id == post.user_id
+      errors.add(:base, '自分の投稿は報告できません')
+    end
+  end
+
+  def no_duplicate_reports
+    if PostsReport.exists?(post_id: post_id, user_id: user_id, status: :pending)
+      errors.add(:base, 'すでにこの投稿を報告しています')
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :liked_themes, through: :likes, source: :likeable, source_type: 'Theme'
   has_many :posts_deletion_requests
   has_many :theme_deletion_requests
+  has_many :posts_reports
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/admin/posts_reports/index.html.erb
+++ b/app/views/admin/posts_reports/index.html.erb
@@ -1,0 +1,45 @@
+<div class="container-fluid">
+  <div class="d-flex justify-content-between mb-4">
+    <h1 class="h3">報告管理</h1>
+  </div>
+
+  <div class="card">
+    <div class="table-responsive">
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th>報告ID</th>
+            <th>報告者</th>
+            <th>報告理由</th>
+            <th>報告日時</th>
+            <th>ステータス</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @posts_reports.each do |report| %>
+            <tr>
+              <td><%= report.id %></td>
+              <td><%= report.user.name %></td>
+              <td>
+                <div><%= t("posts_reports.reason_categories.#{report.reason_category}") %></div>
+              </td>
+              <td><%= l report.created_at, format: :long %></td>
+              <td>
+                <span class="badge bg-<%= report.pending? ? 'warning' : (report.approved? ? 'success' : 'danger') %>">
+                  <%= t("enums.posts_report.status.#{report.status}") %>
+                </span>
+              </td>
+              <td>
+                <%= link_to '詳細', admin_posts_report_path(report), class: 'btn btn-sm btn-info' %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    <div class="card-footer">
+      <%= paginate @posts_reports %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/posts_reports/show.html.erb
+++ b/app/views/admin/posts_reports/show.html.erb
@@ -1,0 +1,75 @@
+<div class="container-fluid">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="h3 mb-0">報告詳細</h1>
+    <div>
+      <% if @posts_report.pending? %>
+        <%= form_with(url: approve_admin_posts_report_path(@posts_report), method: :patch, class: 'd-inline', data: { turbo_confirm: '本当に承認しますか？' }) do |f| %>
+          <%= f.submit '承認する', class: 'btn btn-success' %>
+        <% end %>
+        <%= form_with(url: reject_admin_posts_report_path(@posts_report), method: :patch, class: 'd-inline ms-2', data: { turbo_confirm: '本当に却下しますか？' }) do |f| %>
+          <%= f.submit '却下する', class: 'btn btn-danger' %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <div class="card mb-4">
+        <div class="card-header">
+          <h5 class="card-title mb-0">基本情報</h5>
+        </div>
+        <div class="card-body">
+          <table class="table table-bordered">
+            <tr>
+              <th style="width: 200px">報告ID</th>
+              <td><%= @posts_report.id %></td>
+            </tr>
+            <tr>
+              <th>報告者</th>
+              <td><%= @posts_report.user.name %></td>
+            </tr>
+            <tr>
+              <th>報告日時</th>
+              <td><%= l @posts_report.created_at, format: :long %></td>
+            </tr>
+            <tr>
+              <th>ステータス</th>
+              <td>
+                <span class="badge bg-<%= @posts_report.pending? ? 'warning' : (@posts_report.approved? ? 'success' : 'danger') %>">
+                  <%= t("enums.posts_report.status.#{@posts_report.status}") %>
+                </span>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header">
+          <h5 class="card-title mb-0">対象の投稿</h5>
+        </div>
+        <div class="card-body">
+          <%= @posts_report.post.display_content %>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header">
+          <h5 class="card-title mb-0">報告内容</h5>
+        </div>
+        <div class="card-body">
+          <p><strong>報告理由：</strong>
+            <%= t("posts_reports.reason_categories.#{@posts_report.reason_category}") if @posts_report.reason_category.present? %>
+          </p>
+          <p><strong>詳細：</strong></p>
+          <%= simple_format(h(@posts_report.reason)) %>
+        </div>
+      </div>
+
+      <div class="card-footer text-end">
+        <%= link_to '報告一覧へ戻る', admin_posts_reports_path, class: 'btn btn-secondary' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -34,5 +34,10 @@
         class: "list-group-item list-group-item-action #{controller_name == 'theme_deletion_requests' ? 'active' : ''}" do %>
       お題の削除申請管理
     <% end %>
+
+    <%= link_to admin_posts_reports_path,
+        class: "list-group-item list-group-item-action #{controller_name == 'posts_reports' ? 'active' : ''}" do %>
+      句の報告管理
+    <% end %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -58,6 +58,14 @@
               <%= link_to "削除申請", new_post_posts_deletion_request_path(@post), class: "btn btn-warning" %>
             <% end %>
           </div>
+        <% else %>
+          <div class="mt-3">
+            <% if @post.reported_by?(current_user) %>
+              <button class="btn btn-secondary" disabled>報告済み</button>
+            <% else %>
+              <%= link_to "この投稿を報告", new_post_posts_report_path(@post), class: "btn btn-danger" %>
+            <% end %>
+          </div>
         <% end %>
       </div>
     </div>

--- a/app/views/posts_deletion_requests/show.html.erb
+++ b/app/views/posts_deletion_requests/show.html.erb
@@ -1,5 +1,5 @@
 <%= render 'shared/deletion_request_detail',
-            deletion_request: @posts_deletion_request,
             record: @posts_deletion_request.post,
+            deletion_request: @posts_deletion_request,
             content_type: '投稿',
             return_path: posts_path %>

--- a/app/views/posts_reports/confirm.html.erb
+++ b/app/views/posts_reports/confirm.html.erb
@@ -1,0 +1,5 @@
+<%= render 'shared/report_confirm',
+            record: @post,
+            report: @posts_report,
+            content_type: "投稿",
+            create_path: post_posts_reports_path(@post) %>

--- a/app/views/posts_reports/new.html.erb
+++ b/app/views/posts_reports/new.html.erb
@@ -1,0 +1,9 @@
+<%= render 'shared/report_form',
+            title: "投稿の報告",
+            record: @post,
+            report: @posts_report,
+            url: confirm_post_posts_reports_path(@post),
+            method: :post,
+            content_type: "投稿",
+            submit_text: "確認する",
+            cancel_path: post_path(@post) %>

--- a/app/views/posts_reports/show.html.erb
+++ b/app/views/posts_reports/show.html.erb
@@ -1,0 +1,5 @@
+<%= render 'shared/report_detail',
+            record: @posts_report.post,
+            report: @posts_report,
+            content_type: "投稿",
+            return_path: post_path(@posts_report.post) %>

--- a/app/views/shared/_report_confirm.html.erb
+++ b/app/views/shared/_report_confirm.html.erb
@@ -1,0 +1,39 @@
+<div class="container py-5">
+  <h2 class="mb-4">報告内容の確認</h2>
+
+  <div class="card mb-4">
+    <div class="card-header">
+      報告対象の<%= content_type %>
+    </div>
+    <div class="card-body">
+      <%= record.display_content %>
+    </div>
+  </div>
+
+  <div class="card mb-4">
+    <div class="card-header">
+      報告理由
+    </div>
+    <div class="card-body">
+      <p class="mb-3">
+        <strong>カテゴリ：</strong>
+        <%= t("#{report.class.name.underscore.pluralize}.reason_categories.#{report.reason_category}") %>
+      </p>
+      <strong>詳細：</strong>
+      <%= simple_format(h(report.reason)) %>
+    </div>
+  </div>
+
+  <%= form_with(model: [record, report],
+              url: create_path,
+              method: :post,
+              local: true,
+              data: { turbo: false }) do |f| %>
+    <%= f.hidden_field :reason_category %>
+    <%= f.hidden_field :reason %>
+    <div class="text-center">
+      <%= f.submit "報告する", class: "btn btn-primary" %>
+      <%= f.submit "修正する", name: "back", class: "btn btn-secondary ms-2" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_report_detail.html.erb
+++ b/app/views/shared/_report_detail.html.erb
@@ -1,0 +1,30 @@
+<div class="container py-5">
+  <h2 class="mb-4">報告内容の詳細</h2>
+
+  <div class="card mb-4">
+    <div class="card-header">
+      報告対象の<%= content_type %>
+    </div>
+    <div class="card-body">
+      <%= record.display_content %>
+    </div>
+  </div>
+
+  <div class="card mb-4">
+    <div class="card-header">
+      報告理由
+    </div>
+    <div class="card-body">
+      <p class="mb-3">
+        <strong>カテゴリ：</strong>
+        <%= t("#{report.class.name.underscore.pluralize}.reason_categories.#{report.reason_category}") if report.reason_category.present? %>
+      </p>
+      <strong>詳細：</strong>
+      <%= simple_format(h(report.reason)) %>
+    </div>
+  </div>
+
+  <div class="text-center">
+    <%= link_to "戻る", return_path, class: "btn btn-secondary" %>
+  </div>
+</div>

--- a/app/views/shared/_report_form.html.erb
+++ b/app/views/shared/_report_form.html.erb
@@ -1,0 +1,49 @@
+<div class="container py-5">
+  <h2 class="mb-4"><%= title %></h2>
+
+  <%= form_with(model: [record, report],
+              url: url,
+              method: method,
+              local: true,
+              data: { turbo: false }) do |f| %>
+    <% if report.errors.any? %>
+      <div class="alert alert-danger">
+        <ul class="mb-0">
+          <% report.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="card mb-4">
+      <div class="card-header">
+        報告対象の<%= content_type %>
+      </div>
+      <div class="card-body">
+        <%= record.display_content %>
+      </div>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :reason_category, "報告理由", class: "form-label" %>
+      <span class="text-danger">*</span>
+      <%= f.select :reason_category,
+                    report.class.reason_categories.keys.map { |key| [t("#{report.class.name.underscore.pluralize}.reason_categories.#{key}"), key] },
+                    { selected: :other },
+                    { class: 'form-select' } %>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :reason, "詳細な理由", class: "form-label" %>
+      <span class="text-danger">*</span>
+      <%= f.text_area :reason, rows: 5, class: "form-control" %>
+      <div class="form-text">報告理由を10文字以上1000文字以下で具体的に記入してください。</div>
+    </div>
+
+    <div class="text-center">
+      <%= f.submit submit_text, class: "btn btn-primary" %>
+      <%= link_to "キャンセル", cancel_path, class: "btn btn-secondary ms-2" %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,9 @@ ja:
       tag: 'タグ'
       contact: 'お問い合わせ'
       posts_deletion_request: '削除申請'
+      themes_deletion_request: '削除申請'
+      posts_report: '投稿報告'
+      themes_report: 'お題報告'
     attributes:
       user:
         name: '名前'
@@ -28,6 +31,11 @@ ja:
         privacy_policy_agreed: 'プライバシーポリシー'
       posts_deletion_request:
         reason: '削除理由'
+      themes_deletion_request:
+        reason: '削除理由'
+      posts_report:
+        reason: '詳細な理由'
+        reason_category: '報告理由'
     errors:
       models:
         user:
@@ -76,6 +84,19 @@ ja:
               blank: を入力してください
               too_short: は%{count}文字以上で入力してください
               too_long: は%{count}文字以下で入力してください
+        theme_deletion_request:
+          attributes:
+            reason:
+              blank: を入力してください
+              too_short: は%{count}文字以上で入力してください
+              too_long: は%{count}文字以下で入力してください
+        posts_report:
+          attributes:
+            reason:
+              blank: 'を入力してください'
+              too_short: 'は10文字以上で入力してください'
+            reason_category:
+              blank: 'を選択してください'
   time:
     formats:
       default: "%Y/%m/%d %H:%M"
@@ -140,6 +161,11 @@ ja:
         pending: '審査中'
         approved: '承認済み'
         rejected: '却下'
+    posts_report:
+      status:
+        pending: '審査中'
+        approved: '承認済み'
+        rejected: '却下'
 
   user_sessions:
     new:
@@ -162,3 +188,11 @@ ja:
     user_sessions:
       destroy:
         success: 'ログアウトしました'
+
+  posts_reports:
+    reason_categories:
+      inappropriate: '不適切なコンテンツ'
+      spam: 'スパム'
+      copyright: '著作権侵害'
+      harassment: '嫌がらせ'
+      other: 'その他'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,13 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :posts_reports do
+      member do
+        patch :approve
+        patch :reject
+      end
+    end
+
     resources :contacts, only: [:index, :show, :update]
   end
 
@@ -136,4 +143,13 @@ Rails.application.routes.draw do
     end
   end
   resources :theme_deletion_requests, only: [:show]
+
+  resources :posts do
+    resources :posts_reports, only: [:new, :create] do
+      collection do
+        post :confirm
+      end
+    end
+  end
+  resources :posts_reports, only: [:show]
 end

--- a/db/migrate/20250207065549_create_posts_reports.rb
+++ b/db/migrate/20250207065549_create_posts_reports.rb
@@ -1,0 +1,13 @@
+class CreatePostsReports < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts_reports do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+      t.string :reason_category, null: false
+      t.text :reason, null: false
+      t.integer :status, default: 0
+      t.text :admin_note
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250207125225_fix_posts_reports_reason_category.rb
+++ b/db/migrate/20250207125225_fix_posts_reports_reason_category.rb
@@ -1,0 +1,12 @@
+class FixPostsReportsReasonCategory < ActiveRecord::Migration[7.0]
+  def up
+    change_column :posts_reports, :reason_category, :integer, using: 'reason_category::integer'
+
+    change_column_default :posts_reports, :reason_category, 4
+  end
+
+  def down
+    change_column :posts_reports, :reason_category, :string
+    change_column_default :posts_reports, :reason_category, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_07_014612) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_07_125225) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -117,6 +117,19 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_07_014612) do
     t.index ["user_id"], name: "index_posts_deletion_requests_on_user_id"
   end
 
+  create_table "posts_reports", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.integer "reason_category", default: 4, null: false
+    t.text "reason", null: false
+    t.integer "status", default: 0
+    t.text "admin_note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_posts_reports_on_post_id"
+    t.index ["user_id"], name: "index_posts_reports_on_user_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -178,6 +191,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_07_014612) do
   add_foreign_key "posts_deletion_requests", "posts"
   add_foreign_key "posts_deletion_requests", "themes"
   add_foreign_key "posts_deletion_requests", "users"
+  add_foreign_key "posts_reports", "posts"
+  add_foreign_key "posts_reports", "users"
   add_foreign_key "theme_deletion_requests", "themes"
   add_foreign_key "theme_deletion_requests", "users"
   add_foreign_key "themes", "image_posts"


### PR DESCRIPTION
# 投稿の報告機能の追加

## 概要
投稿に対する不適切なコンテンツの報告機能を実装しました。ユーザーは問題のある投稿を報告でき、管理者は報告内容を確認した上で承認または却下の判断ができるようになります。

## 実装内容
### 報告機能の実装
- 報告理由カテゴリの選択（不適切なコンテンツ、スパム、著作権侵害、嫌がらせ、その他）
- 詳細な理由の入力（10文字以上1000文字以下）
- 報告内容の確認画面
- 報告状況の確認画面
- 同一投稿への重複報告防止
- 自分の投稿への報告防止
- エラーメッセージの日本語化

### 管理画面の実装
- 報告一覧の表示
- 報告詳細の表示
- ステータス管理（審査中、承認済み、却下）
- 報告の承認・却下機能
- 承認時の投稿の自動非表示処理

### 報告ステータス
- 審査中：報告直後の初期状態
- 承認済み：管理者が承認し、投稿が非表示になった状態
- 却下：管理者が報告を却下した状態

## 動作確認項目
1. [x] 報告フォームの基本機能
 - 報告理由カテゴリの選択
 - 詳細理由の文字数チェック（10文字以上1000文字以下）
 - 確認画面の表示と修正機能
 - 報告完了後の詳細画面表示

2. [x] 管理画面の機能
 - 報告一覧の表示
 - 報告詳細の表示
 - 承認・却下機能
 - 非表示投稿の管理

3. [x] エラー表示とバリデーション
 - 適切なエラーメッセージの表示（日本語）
 - バリデーションエラー時のフォーム再表示
 - 重複報告の防止
 - 自分の投稿への報告防止

## 技術的変更点
- Reportableモジュールの作成（将来的なお題報告機能への拡張性を考慮）
- PostsReportモデルの作成
- 投稿報告関連のコントローラー追加
- 管理画面のコントローラー追加
- バリデーションの実装
- モデル間の関連付け（User, Post, PostsReport）
- パーシャルの汎用化（将来的なお題報告機能での再利用を考慮）

## テスト実施内容
- 報告フォームの入力検証
- バリデーションの動作確認
- 管理画面の機能確認
- 報告から承認/却下までの一連のフロー確認
- 投稿の非表示処理の確認

## 影響範囲
- 投稿詳細画面（報告ボタンの追加）
- 管理画面のナビゲーション
- Postモデルの機能拡張
- Userモデルの機能拡張

## 補足事項
- 将来的なお題報告機能への拡張を考慮した設計
- パーシャルの汎用化によるコードの再利用性向上
- 報告理由をカテゴリ化することで、管理者の判断を容易に