### PR TITLE
お題の説明文の文字数変更

### DIFF
--- a/app/models/image_post.rb
+++ b/app/models/image_post.rb
@@ -5,7 +5,7 @@ class ImagePost < ApplicationRecord
   has_one :theme, dependent: :nullify
   has_one_attached :image
 
-  validates :description, length: { maximum: 10 }
+  validates :description, length: { maximum: 20 }
 
   validates :image,
             content_type: {

--- a/app/views/image_posts/new.html.erb
+++ b/app/views/image_posts/new.html.erb
@@ -25,7 +25,7 @@
             <div class="mb-4">
               <%= f.label :description, "説明文", class: "block text-gray-700 text-sm font-bold mb-2" %>
               <%= f.text_area :description, class: "form-control", rows: 3 %>
-              <small class="text-muted">※ 10文字以内</small>
+              <small class="text-muted">※ 20文字以内</small>
             </div>
 
             <div class="text-center">

--- a/app/views/posts/confirm.html.erb
+++ b/app/views/posts/confirm.html.erb
@@ -19,7 +19,7 @@
             </div>
           <% else %>
             <div class="mb-4">
-              <h2 class="h5 mb-3">画像</h2>
+              <h2 class="h5 mb-3">選択した画像</h2>
               <% if @image_post.present? && @image_post.image.present? %>
                 <div class="image-container">
                   <%= image_tag url_for(@image_post.image), class: "w-100 rounded-lg" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
       user: 'ユーザー'
       post: '句'
       tag: 'タグ'
+      image_post: '画像投稿'
       contact: 'お問い合わせ'
       posts_deletion_request: '削除申請'
       themes_deletion_request: '削除申請'
@@ -23,6 +24,9 @@ ja:
         post_tags: 'タグ'
       tag:
         name: 'タグ名'
+      image_post:
+        description: '説明文'
+        image: '画像'
       contact:
         name: 'お名前'
         email: 'メールアドレス'
@@ -69,6 +73,10 @@ ja:
             base:
               tag_required: '俳句か川柳を選択してください'
               one_tag_only: '俳句か川柳のどちらか1つのみ選択できます'
+        image_post:
+          attributes:
+            description:
+              too_long: 'は%{count}文字以内で入力してください'
         contact:
           attributes:
             name:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     depends_on:
       - db
     environment:
-      DATABASE_URL: postgres://postgres:password@db:5432/graduation_project_development
+      DATABASE_URL: postgres://postgres:password@db:5432/hitohi_hitonana_development
       RAILS_ENV: development
       RAILS_SERVE_STATIC_FILES: "true"
       RAILS_LOG_TO_STDOUT: "true"


### PR DESCRIPTION
# お題の説明文の最大文字数を20文字に変更

## 概要
新規投稿時のお題の説明文について、より詳細な説明を可能にするため、最大文字数を10文字から20文字に変更しました。

## 変更内容
### モデル
- `ImagePost`モデルのバリデーションを変更
  - 説明文の最大文字数: 10文字 → 20文字

### ビュー
- 画像投稿フォームの説明文を更新
  - 文字数制限の表示を20文字に変更
- 投稿確認画面の説明文表示を調整

### ローカライズ
- `config/locales/ja.yml`に`image_post`関連の翻訳を追加
  - バリデーションエラーメッセージの日本語化

### 環境設定
- `docker-compose.yml`のデータベース名を更新
  - `graduation_project_development` → `hitohi_hitonana_development`

## 動作確認項目
1. [x] 画像投稿時の説明文入力
  - 20文字以内の入力が正常に保存されること
  - 20文字を超える入力時に適切なエラーメッセージが表示されること
2. [x] 投稿確認画面
  - 説明文が正しく表示されること
3. [x] エラーメッセージ
  - 文字数超過時に日本語のエラーメッセージが表示されること

## 補足事項
- 既存の投稿データには影響しません
- UIの変更は最小限に抑え、説明文の入力欄の文字数制限のみを変更
- データベースのスキーマ変更は不要（text型のため）

## 関連する議論
- お題の説明文をより詳細に書けるようにしたいという要望に対応
- URLの追加については、アプリケーションの本質（句の投稿）を維持するため、今回は見送り