### PR TITLE
お問い合わせの確認メール

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -20,6 +20,7 @@ class ContactsController < ApplicationController
     end
 
     if @contact.save
+      ContactMailer.confirmation_email(@contact).deliver_later
       redirect_to thanks_contacts_path, notice: 'お問い合わせを受け付けました。'
     else
       render 'pages/contact'

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ContactMailer < ApplicationMailer
+  def confirmation_email(contact)
+    @contact = contact
+    mail(
+      to: @contact.email,
+      subject: 'お問い合わせを受け付けました'
+    )
+  end
+end

--- a/app/views/contact_mailer/confirmation_email.html.erb
+++ b/app/views/contact_mailer/confirmation_email.html.erb
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h2>下記のお問い合わせを受け付けました。</h2>
+
+    <div style="margin: 20px 0;">
+      <div style="margin-bottom: 15px;">
+        <div style="font-weight: bold;">お名前</div>
+        <div><%= @contact.name %></div>
+      </div>
+
+      <div style="margin-bottom: 15px;">
+        <div style="font-weight: bold;">メールアドレス</div>
+        <div><%= @contact.email %></div>
+      </div>
+
+      <div style="margin-bottom: 15px;">
+        <div style="font-weight: bold;">お問い合わせ種別</div>
+        <div><%= t("enums.contact.category.#{@contact.category}") %></div>
+      </div>
+
+      <div style="margin-bottom: 15px;">
+        <div style="font-weight: bold;">お問い合わせ内容</div>
+        <div><%= simple_format(h(@contact.content)) %></div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/app/views/contact_mailer/confirmation_email.text.erb
+++ b/app/views/contact_mailer/confirmation_email.text.erb
@@ -1,0 +1,13 @@
+下記のお問い合わせを受け付けました。
+
+お名前
+<%= @contact.name %>
+
+メールアドレス
+<%= @contact.email %>
+
+お問い合わせ種別
+<%= t("enums.contact.category.#{@contact.category}") %>
+
+お問い合わせ内容
+<%= @contact.content %>

--- a/app/views/contacts/thanks.html.erb
+++ b/app/views/contacts/thanks.html.erb
@@ -3,6 +3,7 @@
     <h2 class="mb-3">お問い合わせありがとうございます</h2>
     <p class="mb-4">
       お問い合わせを受け付けました。
+      入力されたメールアドレスに確認メールを送信しました。
     </p>
     <%= link_to "トップページに戻る", root_path, class: "btn btn-primary" %>
   </div>

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :contact do
+    name { |n| "user#{n}@example.com" }
+    email { |n| "User #{n}" }
+    category { 'service' }
+    privacy_policy_agreed { true }
+  end
+end

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -2,9 +2,11 @@
 
 FactoryBot.define do
   factory :contact do
-    name { |n| "user#{n}@example.com" }
-    email { |n| "User #{n}" }
-    category { 'service' }
+    sequence(:name) { |n| "User#{n}" }
+    sequence(:email) { |n| "user#{n}@example.com" }
+    category { "general" }
+    sequence(:content) { |n| "これはテストのお問い合わせ内容#{n}です。" }
     privacy_policy_agreed { true }
+    status { "pending" }
   end
 end

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
   factory :contact do
     sequence(:name) { |n| "User#{n}" }
     sequence(:email) { |n| "user#{n}@example.com" }
-    category { "general" }
+    category { 'general' }
     sequence(:content) { |n| "これはテストのお問い合わせ内容#{n}です。" }
     privacy_policy_agreed { true }
-    status { "pending" }
+    status { 'pending' }
   end
 end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -13,10 +13,14 @@ RSpec.describe ContactMailer, type: :mailer do
       expect(mail.from).to eq(['noreply@hitohi-hitonana.com'])
     end
 
-    it 'renders the body' do
-      expect(mail.body.encoded).to match(contact.name)
-      expect(mail.body.encoded).to match(contact.email)
-      expect(mail.body.encoded).to match(contact.content)
+    it "renders the body" do
+      expect(mail.text_part.body.decoded).to include(contact.name)
+      expect(mail.text_part.body.decoded).to include(contact.email)
+      expect(mail.text_part.body.decoded).to include(contact.content)
+
+      expect(mail.html_part.body.decoded).to include(contact.name)
+      expect(mail.html_part.body.decoded).to include(contact.email)
+      expect(mail.html_part.body.decoded).to include(contact.content)
     end
   end
 end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -7,20 +7,42 @@ RSpec.describe ContactMailer, type: :mailer do
     let(:contact) { create(:contact) }
     let(:mail) { described_class.confirmation_email(contact) }
 
-    it 'renders the headers' do
+    it 'has correct subject' do
       expect(mail.subject).to eq('お問い合わせを受け付けました')
+    end
+
+    it 'sends to correct email' do
       expect(mail.to).to eq([contact.email])
+    end
+
+    it 'sends from correct email' do
       expect(mail.from).to eq(['noreply@hitohi-hitonana.com'])
     end
 
-    it "renders the body" do
-      expect(mail.text_part.body.decoded).to include(contact.name)
-      expect(mail.text_part.body.decoded).to include(contact.email)
-      expect(mail.text_part.body.decoded).to include(contact.content)
+    context 'with email body' do
+      it 'includes contact name in text part' do
+        expect(mail.text_part.body.decoded).to include(contact.name)
+      end
 
-      expect(mail.html_part.body.decoded).to include(contact.name)
-      expect(mail.html_part.body.decoded).to include(contact.email)
-      expect(mail.html_part.body.decoded).to include(contact.content)
+      it 'includes contact email in text part' do
+        expect(mail.text_part.body.decoded).to include(contact.email)
+      end
+
+      it 'includes contact content in text part' do
+        expect(mail.text_part.body.decoded).to include(contact.content)
+      end
+
+      it 'includes contact name in html part' do
+        expect(mail.html_part.body.decoded).to include(contact.name)
+      end
+
+      it 'includes contact email in html part' do
+        expect(mail.html_part.body.decoded).to include(contact.email)
+      end
+
+      it 'includes contact content in html part' do
+        expect(mail.html_part.body.decoded).to include(contact.content)
+      end
     end
   end
 end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContactMailer, type: :mailer do
+  describe '#confirmation_email' do
+    let(:contact) { create(:contact) }
+    let(:mail) { described_class.confirmation_email(contact) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('お問い合わせを受け付けました')
+      expect(mail.to).to eq([contact.email])
+      expect(mail.from).to eq(['noreply@hitohi-hitonana.com'])
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match(contact.name)
+      expect(mail.body.encoded).to match(contact.email)
+      expect(mail.body.encoded).to match(contact.content)
+    end
+  end
+end

--- a/spec/mailers/previews/contact_mailer_preview.rb
+++ b/spec/mailers/previews/contact_mailer_preview.rb
@@ -6,7 +6,7 @@ class ContactMailerPreview < ActionMailer::Preview
     contact = Contact.new(
       name: 'Preview User',
       email: 'preview@example.com',
-      category: 'service',
+      category: 'general',
       content: "これはテストのお問い合わせ内容です。\n改行を含む内容です。"
     )
     ContactMailer.confirmation_email(contact)

--- a/spec/mailers/previews/contact_mailer_preview.rb
+++ b/spec/mailers/previews/contact_mailer_preview.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/contact_mailer_mailer
+class ContactMailerPreview < ActionMailer::Preview
+  def confirmation_email
+    contact = Contact.new(
+      name: 'Preview User',
+      email: 'preview@example.com',
+      category: 'service',
+      content: "これはテストのお問い合わせ内容です。\n改行を含む内容です。"
+    )
+    ContactMailer.confirmation_email(contact)
+  end
+end


### PR DESCRIPTION
# お問い合わせ確認メール機能の実装

## 概要
お問い合わせフォームからの送信時に、入力内容を記載した確認メールを送信する機能を実装しました。

## 変更内容
### 機能
- お問い合わせ確認メール機能の追加
  - フォーム送信時に確認メールを送信
  - HTMLメールとテキストメールの両方に対応
  - お問い合わせ内容（名前、メールアドレス、種別、内容）を確認メールに記載
  - サンクスページで確認メール送信の通知を表示

### メール実装
- `ContactMailer`クラスの作成
  - `confirmation_email`メソッドの実装
  - HTMLとテキスト形式のメールテンプレート作成
- メール送信の非同期処理化（`deliver_later`の使用）

### テスト
- メーラーのスペックテストを追加
  - メールヘッダーのテスト（件名、送信元、送信先）
  - メール本文の内容テスト
- メールプレビュー機能の実装
  - 開発環境でのメール確認用

## 動作確認項目
1. [x] お問い合わせフォームの送信
  - 確認メールが送信されること
  - サンクスページに通知が表示されること
2. [x] メール内容
  - 入力内容が正しく表示されること
  - 文字化けが発生しないこと
  - 改行が適切に処理されること
3. [x] 開発環境
  - letter_opener_webでメールが確認できること
  - プレビュー機能が動作すること
4. [x] 本番環境
  - SMTPでメールが送信されること
  - 実際のメールアドレスで受信できること

## 補足事項
- メール送信にはお名前.comのサービスを使用
- メールテンプレートはお問い合わせ確認画面の表示内容を踏襲
- 開発環境では`letter_opener_web`を使用してブラウザでメールを確認可能
  - `/letter_opener`にアクセスして確認

## 今後の展望
- メール送信失敗時のエラー通知の実装
- メールテンプレートのデザイン改善
- メール本文の多言語対応