### PR TITLE
セキュリティGemの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,10 @@ gem 'recaptcha'
 
 gem 'sidekiq'
 
+gem 'rack-attack'
+
+gem 'secure_headers'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
@@ -98,6 +102,8 @@ group :development do
   gem 'rubocop-rspec', require: false
 
   gem 'letter_opener_web'
+
+  gem 'brakeman'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
+    brakeman (7.0.0)
+      racc
     builder (3.3.0)
     capybara (3.40.0)
       addressable
@@ -237,6 +239,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.10)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.8.6)
@@ -323,6 +327,7 @@ GEM
       ffi (~> 1.12)
       logger
     rubyzip (2.3.2)
+    secure_headers (7.1.0)
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -386,6 +391,7 @@ DEPENDENCIES
   active_storage_validations
   activestorage-cloudinary-service
   bootsnap
+  brakeman
   capybara
   cloudinary
   cssbundling-rails
@@ -402,6 +408,7 @@ DEPENDENCIES
   mini_magick
   pg (~> 1.1)
   puma (~> 5.0)
+  rack-attack
   rails (~> 7.0.4, >= 7.0.4.3)
   recaptcha
   rspec-rails
@@ -410,6 +417,7 @@ DEPENDENCIES
   rubocop-factory_bot
   rubocop-rails
   rubocop-rspec
+  secure_headers
   selenium-webdriver
   sidekiq
   sorcery

--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -11,11 +11,11 @@ module Sortable
       records.order(created_at: :asc)
     when 'most_likes'
       records.left_joins(:likes)
-             .group("#{records.table.name}.id")
+             .group(records.table_name)
              .order('COUNT(likes.id) DESC, created_at DESC')
     when 'least_likes'
       records.left_joins(:likes)
-             .group("#{records.table.name}.id")
+             .group(records.table_name)
              .order('COUNT(likes.id) ASC, created_at DESC')
     when 'most_posts'
       if records.model == Theme

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,8 @@ module App
 
     config.active_storage.variant_processor = :mini_magick
 
+    config.middleware.use Rack::Attack
+
     # config.active_job.queue_adapter = :sidekiq
 
     # Configuration for the application, engines, and railties goes here.

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,19 @@
+class Rack::Attack
+  Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+  throttle('req/ip/login', limit: 5, period: 20.seconds) do |req|
+    if req.path == '/login' && req.post?
+      req.ip
+    end
+  end
+
+  throttle('req/ip', limit: 300, period: 5.minutes) do |req|
+    req.ip unless req.path.start_with?('/assets')
+  end
+
+  throttle('req/ip/admin', limit: 30, period: 5.minutes) do |req|
+    if req.path.start_with?('/admin')
+      req.ip
+    end
+  end
+end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,0 +1,22 @@
+SecureHeaders::Configuration.default do |config|
+  config.x_frame_options = "DENY"
+  config.x_content_type_options = "nosniff"
+  config.x_xss_protection = "1; mode=block"
+  config.x_download_options = "noopen"
+  config.x_permitted_cross_domain_policies = "none"
+  config.referrer_policy = %w(origin-when-cross-origin strict-origin-when-cross-origin)
+
+  config.csp = {
+    default_src: %w('self'),
+    script_src: %w('self'),
+    style_src: %w('self'),
+    img_src: %w('self' data: *.cloudinary.com res.cloudinary.com),
+    connect_src: %w('self'),
+    font_src: %w('self'),
+    object_src: %w('none'),
+    frame_ancestors: %w('none'),
+    form_action: %w('self'),
+    base_uri: %w('self'),
+    manifest_src: %w('self')
+  }
+end


### PR DESCRIPTION
# セキュリティ関連のGem導入とSQL Injection対策の実装

## 概要
セキュリティ強化のため、以下の対策を実装しました：
1. セキュリティ関連の3つのGemを導入
2. SQL Injectionの脆弱性に対する修正
3. リクエスト制限の実装
4. セキュリティヘッダーの設定

## 変更内容
### セキュリティGemの追加
- `rack-attack`: DoS攻撃やブルートフォース攻撃への対策
- `secure_headers`: セキュリティヘッダーの設定
- `brakeman`: セキュリティ診断ツール（開発環境のみ）

### 設定ファイルの追加
- `config/initializers/rack_attack.rb`
  - ログイン試行の制限（5回/20秒）
  - 全体的なリクエスト制限（300回/5分）

- `config/initializers/secure_headers.rb`
  - XSS対策
  - クリックジャッキング対策
  - CSP（Content Security Policy）の設定
  - Cloudinaryドメインの許可設定

### SQL Injection対策
- `app/controllers/concerns/sortable.rb`
  - 安全なテーブル名の参照方法に修正
  - 機能への影響なし

### その他の変更
- `config/application.rb`
  - Rack::Attackの有効化

## 動作確認項目
1. [x] アプリケーションの基本機能
   - ユーザー登録・ログイン
   - 投稿機能
   - いいね機能
   - ソート機能

2. [x] セキュリティ機能
   - ログイン試行制限の動作確認
   - 画像アップロード（Cloudinary）の動作確認
   - CSPヘッダーの設定確認

3. [x] brakemanによる診断
   - セキュリティ診断を実行
   - 重要な警告に対する対応を実施

## 技術的補足
- Cloudinaryとの連携のため、CSPの設定で`img_src`に`cloudinary.com`を許可
- SQL Injectionの対策として`table_name`メソッドを使用
- リクエスト制限の値は一般的な推奨値を採用

## 今後の課題
- Rails 7.0.8.6のサポート期限（2025-04-01）に向けたアップグレード計画の検討
- 管理者ページへのアクセス制限の追加検討
- セキュリティ監視の強化