### PR TITLE
管理者からのお知らせ

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Admin
+  class AnnouncementsController < Admin::BaseController
+    def index
+      @announcements = Announcement.recent.page(params[:page])
+    end
+
+    def new
+      @announcement = Announcement.new
+    end
+
+    def edit
+      @announcement = Announcement.find(params[:id])
+    end
+
+    def create
+      @announcement = Announcement.new(announcement_params)
+      @announcement.admin = current_user
+
+      if @announcement.save
+        redirect_to admin_announcements_path, success: t('.success')
+      else
+        render :new
+      end
+    end
+
+    def update
+      @announcement = Announcement.find(params[:id])
+      if @announcement.update(announcement_params)
+        redirect_to admin_announcements_path, success: t('.success')
+      else
+        render :edit
+      end
+    end
+
+    def publish
+      @announcement = Announcement.find(params[:id])
+      if @announcement.update(status: :published, published_at: Time.current)
+        redirect_to admin_announcements_path, success: t('.success')
+      else
+        redirect_to admin_announcements_path, error: t('.failure')
+      end
+    end
+
+    def archive
+      @announcement = Announcement.find(params[:id])
+      if @announcement.update(status: :archived)
+        redirect_to admin_announcements_path, success: t('.success')
+      else
+        redirect_to admin_announcements_path, error: t('.failure')
+      end
+    end
+
+    private
+
+    def announcement_params
+      params.require(:announcement).permit(:title, :content, :status, :priority, :published_at)
+    end
+  end
+end

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AnnouncementsController < ApplicationController
+  def index
+    @announcements = Announcement.active.recent.page(params[:page])
+  end
+
+  def show
+    @announcement = Announcement.active.find(params[:id])
+    mark_as_read if logged_in?
+  end
+
+  private
+
+  def mark_as_read
+    current_user.announcement_reads.find_or_create_by(announcement: @announcement)
+  end
+end

--- a/app/helpers/admin/announcements_helper.rb
+++ b/app/helpers/admin/announcements_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  module AnnouncementsHelper
+    def announcement_status_color(announcement)
+      case announcement.status
+      when 'draft' then 'secondary'
+      when 'published' then 'success'
+      when 'archived' then 'dark'
+      end
+    end
+
+    def announcement_priority_color(announcement)
+      case announcement.priority
+      when 'normal' then 'info'
+      when 'important' then 'warning'
+      when 'urgent' then 'danger'
+      end
+    end
+  end
+end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Announcement < ApplicationRecord
+  belongs_to :admin, class_name: 'User'
+
+  has_many :announcement_reads, dependent: :destroy
+  has_many :readers, through: :announcement_reads, source: :user
+
+  validates :title, presence: true
+  validates :content, presence: true
+
+  enum :status, { draft: 0, published: 1, archived: 2 }
+  enum :priority, { normal: 0, important: 1, urgent: 2 }
+
+  scope :active, -> { where(status: :published) }
+  scope :recent, -> { order(created_at: :desc) }
+end

--- a/app/models/announcement_read.rb
+++ b/app/models/announcement_read.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AnnouncementRead < ApplicationRecord
+  belongs_to :announcement
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :announcement_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
   has_many :themes_deletion_requests
   has_many :posts_reports
   has_many :themes_reports
+  has_many :announcement_reads, dependent: :destroy
+  has_many :read_announcements, through: :announcement_reads, source: :announcement
 
   validates :password,
             length: { minimum: 8 },
@@ -62,6 +64,10 @@ class User < ApplicationRecord
     return true if last_general_post_at.nil?
 
     last_general_post_at.in_time_zone('Asia/Tokyo').to_date < Date.current.in_time_zone('Asia/Tokyo').to_date
+  end
+
+  def unread_announcements
+    Announcement.active.where.not(id: read_announcements.pluck(:id))
   end
 
   private

--- a/app/views/admin/announcements/edit.html.erb
+++ b/app/views/admin/announcements/edit.html.erb
@@ -1,0 +1,48 @@
+<h2>お知らせ編集</h2>
+
+<div class="card">
+  <div class="card-body">
+    <%= form_with(model: [:admin, @announcement], local: true) do |f| %>
+      <% if @announcement.errors.any? %>
+        <div class="alert alert-danger">
+          <h5><%= pluralize(@announcement.errors.count, 'error') %>が発生しました:</h5>
+          <ul>
+            <% @announcement.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="mb-3">
+        <%= f.label :title, class: 'form-label' %>
+        <%= f.text_field :title, class: 'form-control' %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :content, class: 'form-label' %>
+        <%= f.text_area :content, rows: 10, class: 'form-control' %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :status, class: 'form-label' %>
+        <%= f.select :status, Announcement.statuses_i18n.invert, {}, class: 'form-select' %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :priority, class: 'form-label' %>
+        <%= f.select :priority, Announcement.priorities_i18n.invert, {}, class: 'form-select' %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :published_at, class: 'form-label' %>
+        <%= f.datetime_field :published_at, class: 'form-control' %>
+      </div>
+
+      <div class="d-flex gap-2">
+        <%= f.submit class: 'btn btn-primary' %>
+        <%= link_to '戻る', admin_announcements_path, class: 'btn btn-secondary' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/announcements/index.html.erb
+++ b/app/views/admin/announcements/index.html.erb
@@ -1,0 +1,44 @@
+<h2>お知らせ一覧</h2>
+
+<div class="mb-3">
+  <%= link_to '新規作成', new_admin_announcement_path, class: 'btn btn-primary' %>
+</div>
+
+<div class="card">
+  <div class="card-body">
+    <div class="table-responsive">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>タイトル</th>
+            <th>ステータス</th>
+            <th>優先度</th>
+            <th>公開日時</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @announcements.each do |announcement| %>
+            <tr>
+              <td><%= announcement.title %></td>
+              <td><span class="badge bg-<%= announcement.draft? ? 'secondary' : (announcement.published? ? 'success' : 'dark') %>"><%= announcement.status_i18n %></span></td>
+              <td><span class="badge bg-<%= announcement.urgent? ? 'danger' : (announcement.important? ? 'warning' : 'info') %>"><%= announcement.priority_i18n %></span></td>
+              <td><%= l announcement.published_at if announcement.published_at %></td>
+              <td>
+                <%= link_to '編集', edit_admin_announcement_path(announcement), class: 'btn btn-sm btn-outline-primary me-1' %>
+                <% if announcement.draft? %>
+                  <%= button_to '公開', publish_admin_announcement_path(announcement), method: :patch, class: 'btn btn-sm btn-outline-success', form: { class: 'd-inline-block' } %>
+                <% elsif announcement.published? %>
+                  <%= button_to 'アーカイブ', archive_admin_announcement_path(announcement), method: :patch, class: 'btn btn-sm btn-outline-secondary', form: { class: 'd-inline-block' } %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="card-footer">
+    <%= paginate @announcements %>
+  </div>
+</div>

--- a/app/views/admin/announcements/new.html.erb
+++ b/app/views/admin/announcements/new.html.erb
@@ -1,0 +1,48 @@
+<h2>お知らせ新規作成</h2>
+
+<div class="card">
+  <div class="card-body">
+    <%= form_with(model: [:admin, @announcement], local: true) do |f| %>
+      <% if @announcement.errors.any? %>
+        <div class="alert alert-danger">
+          <h5><%= pluralize(@announcement.errors.count, 'error') %>が発生しました:</h5>
+          <ul>
+            <% @announcement.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="mb-3">
+        <%= f.label :title, class: 'form-label' %>
+        <%= f.text_field :title, class: 'form-control' %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :content, class: 'form-label' %>
+        <%= f.text_area :content, rows: 10, class: 'form-control' %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :status, class: 'form-label' %>
+        <%= f.select :status, Announcement.statuses_i18n.invert, {}, class: 'form-select' %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :priority, class: 'form-label' %>
+        <%= f.select :priority, Announcement.priorities_i18n.invert, {}, class: 'form-select' %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :published_at, class: 'form-label' %>
+        <%= f.datetime_field :published_at, class: 'form-control' %>
+      </div>
+
+      <div class="d-flex gap-2">
+        <%= f.submit class: 'btn btn-primary' %>
+        <%= link_to '戻る', admin_announcements_path, class: 'btn btn-secondary' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -44,5 +44,10 @@
         class: "list-group-item list-group-item-action #{controller_name == 'themes_reports' ? 'active' : ''}" do %>
       お題の報告管理
     <% end %>
+
+    <%= link_to admin_announcements_path,
+        class: "list-group-item list-group-item-action #{controller_name == 'announcements' ? 'active' : ''}" do %>
+      お知らせ管理
+    <% end %>
   </div>
 </div>

--- a/app/views/announcements/index.html.erb
+++ b/app/views/announcements/index.html.erb
@@ -1,0 +1,29 @@
+<div class="container">
+  <h2 class="mb-4">お知らせ一覧</h2>
+
+  <div class="row">
+    <% @announcements.each do |announcement| %>
+      <div class="col-12 mb-4">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title"><%= link_to announcement.title, announcement_path(announcement) %></h5>
+            <div class="mb-2">
+              <span class="badge bg-<%= announcement.urgent? ? 'danger' : (announcement.important? ? 'warning' : 'info') %>">
+                <%= announcement.priority_i18n %>
+              </span>
+              <small class="text-muted ms-2">
+                <%= l announcement.published_at if announcement.published_at %>
+              </small>
+            </div>
+            <p class="card-text"><%= truncate(announcement.content, length: 200) %></p>
+            <%= link_to '続きを読む', announcement_path(announcement), class: 'btn btn-link p-0' %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="d-flex justify-content-center">
+    <%= paginate @announcements %>
+  </div>
+</div>

--- a/app/views/announcements/show.html.erb
+++ b/app/views/announcements/show.html.erb
@@ -1,0 +1,19 @@
+<div class="container">
+  <div class="card">
+    <div class="card-body">
+      <h3 class="card-title mb-3"><%= @announcement.title %></h3>
+      <div class="mb-3">
+        <span class="badge bg-<%= @announcement.urgent? ? 'danger' : (@announcement.important? ? 'warning' : 'info') %>">
+          <%= @announcement.priority_i18n %>
+        </span>
+        <small class="text-muted ms-2">
+          <%= l @announcement.published_at if @announcement.published_at %>
+        </small>
+      </div>
+      <div class="card-text">
+        <%= simple_format @announcement.content %>
+      </div>
+      <%= link_to '一覧に戻る', announcements_path, class: 'btn btn-secondary' %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,6 +10,17 @@
 
     <div class="header-right">
       <% if logged_in? %>
+        <%= link_to announcements_path, class: 'text-decoration-none text-dark me-3' do %>
+          <span class="fw-medium">
+            お知らせ
+            <% if current_user.unread_announcements.exists? %>
+              <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="font-size: 0.65rem;">
+                <%= current_user.unread_announcements.count %>
+                <span class="visually-hidden">未読のお知らせ</span>
+              </span>
+            <% end %>
+          </span>
+        <% end %>
         <%= link_to profile_path, class: 'text-decoration-none text-dark' do %>
           <span class="fw-medium"><%= current_user.name %></span>
         <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,7 @@ ja:
       posts_report: '投稿報告'
       themes_report: 'お題報告'
       contact_reply_template: '返信テンプレート'
+      announcement: 'お知らせ'
     attributes:
       user:
         name: '名前'
@@ -49,6 +50,12 @@ ja:
       themes_report:
         reason: '詳細な理由'
         reason_category: '報告理由'
+      announcement:
+        title: 'タイトル'
+        content: '内容'
+        status: 'ステータス'
+        priority: '優先度'
+        published_at: '公開日時'
 
     errors:
       models:
@@ -213,6 +220,15 @@ ja:
         pending: '審査中'
         approved: '承認済み'
         rejected: '却下'
+    announcement:
+        status:
+          draft: '下書き'
+          published: '公開'
+          archived: 'アーカイブ'
+        priority:
+          normal: '通常'
+          important: '重要'
+          urgent: '緊急'
 
   user_sessions:
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,13 @@ Rails.application.routes.draw do
         post :reply
       end
     end
+
+    resources :announcements do
+      member do
+        patch :publish
+        patch :archive
+      end
+    end
   end
 
   root 'home#index'
@@ -178,6 +185,12 @@ Rails.application.routes.draw do
   resources :users do
     member do
       post :resend_confirmation
+    end
+  end
+
+  resources :announcements, only: [:index, :show] do
+    member do
+      post :mark_as_read
     end
   end
 

--- a/db/migrate/20250224054644_create_announcements.rb
+++ b/db/migrate/20250224054644_create_announcements.rb
@@ -1,0 +1,14 @@
+class CreateAnnouncements < ActiveRecord::Migration[7.0]
+  def change
+    create_table :announcements do |t|
+      t.string :title, null: false
+      t.text :content, null: false
+      t.integer :status, null: false, default: 0
+      t.integer :priority, null: false, default: 0
+      t.datetime :published_at
+      t.references :admin, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250224054758_create_announcement_reads.rb
+++ b/db/migrate/20250224054758_create_announcement_reads.rb
@@ -1,0 +1,12 @@
+class CreateAnnouncementReads < ActiveRecord::Migration[7.0]
+  def change
+    create_table :announcement_reads do |t|
+      t.references :announcement, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :announcement_reads, [:announcement_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_22_000144) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_24_054758) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,28 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_22_000144) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "announcement_reads", force: :cascade do |t|
+    t.bigint "announcement_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["announcement_id", "user_id"], name: "index_announcement_reads_on_announcement_id_and_user_id", unique: true
+    t.index ["announcement_id"], name: "index_announcement_reads_on_announcement_id"
+    t.index ["user_id"], name: "index_announcement_reads_on_user_id"
+  end
+
+  create_table "announcements", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "content", null: false
+    t.integer "status", default: 0, null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "published_at"
+    t.bigint "admin_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["admin_id"], name: "index_announcements_on_admin_id"
   end
 
   create_table "contact_reply_templates", force: :cascade do |t|
@@ -213,6 +235,9 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_22_000144) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "announcement_reads", "announcements"
+  add_foreign_key "announcement_reads", "users"
+  add_foreign_key "announcements", "users", column: "admin_id"
   add_foreign_key "likes", "users"
   add_foreign_key "post_tags", "posts"
   add_foreign_key "post_tags", "tags"

--- a/spec/controllers/admin/announcements_controller_spec.rb
+++ b/spec/controllers/admin/announcements_controller_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::AnnouncementsController, type: :controller do
+  let(:admin) { create(:user, role: :admin) }
+  let(:user) { create(:user, role: :general) }
+  let(:announcement) { create(:announcement, admin: admin) }
+  let(:valid_attributes) do
+    {
+      title: 'テストお知らせ',
+      content: 'テスト本文です',
+      status: 'published',
+      priority: 'normal',
+      published_at: Time.current
+    }
+  end
+  let(:invalid_attributes) { { title: '', content: '' } }
+
+  describe 'GET #index' do
+    context 'as an admin user' do
+      before do
+        login_user(admin)
+        get :index
+      end
+
+      it 'returns a success response' do
+        expect(response).to be_successful
+      end
+
+      it 'assigns all announcements as @announcements' do
+        announcement
+        expect(assigns(:announcements)).to include(announcement)
+      end
+    end
+
+    context 'as a general user' do
+      before do
+        login_user(user)
+        get :index
+      end
+
+      it 'redirects to root path' do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe 'GET #new' do
+    before do
+      login_user(admin)
+      get :new
+    end
+
+    it 'returns a success response' do
+      expect(response).to be_successful
+    end
+
+    it 'assigns a new announcement as @announcement' do
+      expect(assigns(:announcement)).to be_a_new(Announcement)
+    end
+  end
+
+  describe 'POST #create' do
+    before do
+      login_user(admin)
+    end
+
+    context 'with valid params' do
+      it 'creates a new Announcement' do
+        expect do
+          post :create, params: { announcement: valid_attributes }
+        end.to change(Announcement, :count).by(1)
+      end
+
+      it 'redirects to the announcements list' do
+        post :create, params: { announcement: valid_attributes }
+        expect(response).to redirect_to(admin_announcements_path)
+      end
+    end
+
+    context 'with invalid params' do
+      it 'does not create a new Announcement' do
+        expect do
+          post :create, params: { announcement: invalid_attributes }
+        end.not_to change(Announcement, :count)
+      end
+
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: { announcement: invalid_attributes }
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    before do
+      login_user(admin)
+      get :edit, params: { id: announcement.to_param }
+    end
+
+    it 'returns a success response' do
+      expect(response).to be_successful
+    end
+
+    it 'assigns the requested announcement as @announcement' do
+      expect(assigns(:announcement)).to eq(announcement)
+    end
+  end
+
+  describe 'PATCH #update' do
+    before do
+      login_user(admin)
+    end
+
+    context 'with valid params' do
+      let(:new_attributes) { { title: '更新されたタイトル' } }
+
+      it 'updates the requested announcement' do
+        patch :update, params: { id: announcement.to_param, announcement: new_attributes }
+        announcement.reload
+        expect(announcement.title).to eq('更新されたタイトル')
+      end
+
+      it 'redirects to the announcements list' do
+        patch :update, params: { id: announcement.to_param, announcement: valid_attributes }
+        expect(response).to redirect_to(admin_announcements_path)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        patch :update, params: { id: announcement.to_param, announcement: invalid_attributes }
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'PATCH #publish' do
+    let(:draft_announcement) { create(:announcement, admin: admin, status: :draft) }
+
+    before do
+      login_user(admin)
+      patch :publish, params: { id: draft_announcement.to_param }
+    end
+
+    it 'updates the announcement status to published' do
+      draft_announcement.reload
+      expect(draft_announcement.status).to eq('published')
+    end
+
+    it 'sets published_at timestamp' do
+      draft_announcement.reload
+      expect(draft_announcement.published_at).not_to be_nil
+    end
+
+    it 'redirects to the announcements list' do
+      expect(response).to redirect_to(admin_announcements_path)
+    end
+  end
+
+  describe 'PATCH #archive' do
+    let(:published_announcement) { create(:announcement, admin: admin, status: :published) }
+
+    before do
+      login_user(admin)
+      patch :archive, params: { id: published_announcement.to_param }
+    end
+
+    it 'updates the announcement status to archived' do
+      published_announcement.reload
+      expect(published_announcement.status).to eq('archived')
+    end
+
+    it 'redirects to the announcements list' do
+      expect(response).to redirect_to(admin_announcements_path)
+    end
+  end
+end

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnnouncementsController, type: :controller do
+  let(:user) { create(:user) }
+  let(:announcement) { create(:announcement, status: :published) }
+
+  describe 'GET #index' do
+    before do
+      announcement
+      get :index
+    end
+
+    it 'returns a success response' do
+      expect(response).to be_successful
+    end
+
+    it 'assigns only published announcements as @announcements' do
+      draft_announcement = create(:announcement, status: :draft)
+      archived_announcement = create(:announcement, status: :archived)
+
+      expect(assigns(:announcements)).to include(announcement)
+      expect(assigns(:announcements)).not_to include(draft_announcement, archived_announcement)
+    end
+  end
+
+  describe 'GET #show' do
+    context 'for a published announcement' do
+      before do
+        get :show, params: { id: announcement.to_param }
+      end
+
+      it 'returns a success response' do
+        expect(response).to be_successful
+      end
+
+      it 'assigns the requested announcement as @announcement' do
+        expect(assigns(:announcement)).to eq(announcement)
+      end
+    end
+
+    context 'for a draft announcement' do
+      let(:draft_announcement) { create(:announcement, status: :draft) }
+
+      it 'raises ActiveRecord::RecordNotFound' do
+        expect do
+          get :show, params: { id: draft_announcement.to_param }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe 'POST #mark_as_read' do
+    before do
+      login_user(user)
+    end
+
+    it 'creates a new announcement_read record' do
+      expect do
+        post :mark_as_read, params: { id: announcement.to_param }
+      end.to change(AnnouncementRead, :count).by(1)
+    end
+
+    it 'does not create duplicate records' do
+      create(:announcement_read, user: user, announcement: announcement)
+
+      expect do
+        post :mark_as_read, params: { id: announcement.to_param }
+      end.not_to change(AnnouncementRead, :count)
+    end
+  end
+end

--- a/spec/factories/announcement_reads.rb
+++ b/spec/factories/announcement_reads.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :announcement_read do
+    announcement
+    user
+  end
+end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :announcement do
+    sequence(:title) { |n| "お知らせタイトル#{n}" }
+    content { 'お知らせ本文です。' }
+    status { :published }
+    priority { :normal }
+    published_at { Time.current }
+    admin factory: %i[user], role: :admin
+  end
+end

--- a/spec/models/announcement_read_spec.rb
+++ b/spec/models/announcement_read_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AnnouncementRead, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:announcement) }
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:announcement_id) }
+  end
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Announcement, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:content) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:admin).class_name('User') }
+    it { is_expected.to have_many(:announcement_reads).dependent(:destroy) }
+    it { is_expected.to have_many(:readers).through(:announcement_reads).source(:user) }
+  end
+
+  describe 'enums' do
+    it { is_expected.to define_enum_for(:status).with_values(draft: 0, published: 1, archived: 2) }
+    it { is_expected.to define_enum_for(:priority).with_values(normal: 0, important: 1, urgent: 2) }
+  end
+
+  describe 'scopes' do
+    describe '.active' do
+      let!(:draft_announcement) { create(:announcement, status: :draft) }
+      let!(:published_announcement) { create(:announcement, status: :published) }
+      let!(:archived_announcement) { create(:announcement, status: :archived) }
+
+      it 'returns only published announcements' do
+        expect(described_class.active).to include(published_announcement)
+        expect(described_class.active).not_to include(draft_announcement, archived_announcement)
+      end
+    end
+
+    describe '.recent' do
+      let!(:old_announcement) { create(:announcement, created_at: 2.days.ago) }
+      let!(:new_announcement) { create(:announcement, created_at: 1.day.ago) }
+
+      it 'orders announcements by created_at desc' do
+        expect(described_class.recent.first).to eq(new_announcement)
+        expect(described_class.recent.last).to eq(old_announcement)
+      end
+    end
+  end
+end

--- a/spec/support/sorcery.rb
+++ b/spec/support/sorcery.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Sorcery
+  module TestHelpers
+    module Rails
+      def login_user(user)
+        @request.session[:user_id] = user.id
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Sorcery::TestHelpers::Rails, type: :controller
+end


### PR DESCRIPTION
# 管理者お知らせ機能の実装

## 概要
管理者がユーザー向けのお知らせを作成・管理できる機能を実装しました。管理者はお知らせの作成・編集・公開・アーカイブが可能で、ユーザーは公開されたお知らせを閲覧できます。また、既読管理機能も実装し、ユーザーごとの既読状態を追跡します。

## 変更内容
### 機能追加
- お知らせ管理機能（作成・編集・公開・アーカイブ）
- ユーザー向けお知らせ一覧・詳細表示
- お知らせの優先度設定（通常・重要・緊急）
- ユーザーごとの既読管理

### 変更ファイル
- `db/migrate/20250224054644_create_announcements.rb`
 - お知らせテーブルの作成
- `db/migrate/20250224054758_create_announcement_reads.rb`
 - お知らせ既読管理テーブルの作成
- `app/models/announcement.rb`
 - お知らせモデルの実装
- `app/models/announcement_read.rb`
 - お知らせ既読管理モデルの実装
- `app/models/user.rb`
 - 未読お知らせ取得メソッドの追加
- `app/controllers/admin/announcements_controller.rb`
 - 管理者用コントローラー
- `app/controllers/announcements_controller.rb`
 - ユーザー用コントローラー
- `app/views/admin/announcements/*`
 - 管理画面のビューファイル
- `app/views/announcements/*`
 - ユーザー向けビューファイル
- `app/views/admin/shared/_sidebar.html.erb`
 - 管理画面サイドバーにお知らせ管理リンク追加
- `app/views/shared/_header.html.erb`
 - ユーザーヘッダーにお知らせリンク追加
- `config/routes.rb`
 - ルーティング設定
- `config/locales/ja.yml`
 - 日本語化対応
- `spec/*`
 - テストファイル

## 動作確認項目
1. [x] 管理者機能
  - お知らせの作成・編集・公開・アーカイブが正常に動作すること
  - 優先度の設定が反映されること
  - サイドバーからアクセス可能なこと

2. [x] ユーザー機能
  - 公開されたお知らせのみが表示されること
  - お知らせの詳細が閲覧できること
  - 閲覧したお知らせが既読になること

3. [x] UI表示
  - 優先度に応じた表示がされること
  - ヘッダーからアクセス可能なこと